### PR TITLE
Fix a bug with late-binding closure in enum parsing

### DIFF
--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -106,7 +106,7 @@ def _create_parser(tp: Type[Dataclass]) -> ArgumentParser:
                 dest=field.name,
                 help=f"Override field {field.name}.",
                 required=field.default is MISSING and field.default_factory is MISSING,
-                type=lambda x: field.type[x],
+                type=field.type.__getitem__,
             )
 
         else:

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -106,7 +106,7 @@ def _create_parser(tp: Type[Dataclass]) -> ArgumentParser:
                 dest=field.name,
                 help=f"Override field {field.name}.",
                 required=field.default is MISSING and field.default_factory is MISSING,
-                type=field.type.__getitem__,
+                type=partial(_get_enum_by_name, enum_type=field.type),  # type: ignore
             )
 
         else:
@@ -126,6 +126,13 @@ def _parse_bool(arg: str) -> bool:
     elif arg.lower() == "false" or arg == "0":
         return False
     raise TypeError(f"Unable to convert {arg} to boolean.")
+
+
+def _get_enum_by_name(name: str, enum_type: Type[Enum]) -> Union[Enum, str]:
+    try:
+        return enum_type[name]
+    except KeyError:
+        return name
 
 
 def _parse_datetime(date_string: str, is_date: bool, date_format: Optional[str] = None) -> Union[date, datetime]:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -116,6 +116,7 @@ class TestParseChoices:
         @dataclass
         class TConfig:
             an_enum: AnEnum
+            a_string: str = "a_string"
 
         with raises(SystemExit):
             parse(TConfig, [])
@@ -124,7 +125,7 @@ class TestParseChoices:
         assert t.an_enum == AnEnum.one
 
     def test_str_enum(self):
-        class AnEnum(str, Enum):
+        class AnEnum(Enum):
             one = "one"
             two = "two"
             three = "three"
@@ -133,6 +134,7 @@ class TestParseChoices:
         class TConfig:
             an_enum: AnEnum
             another_enum: AnEnum = AnEnum.three
+            an_int: int = 5
 
         with raises(SystemExit):
             parse(TConfig, [])

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -147,6 +147,9 @@ class TestParseChoices:
         assert t.an_enum == AnEnum.one
         assert t.another_enum == AnEnum.two
 
+        with raises(SystemExit):
+            parse(TConfig, ["--an-enum", "four"])
+
     def test_str_literal(self):
         @dataclass
         class TConfig:


### PR DESCRIPTION
Unsure why ruff didn't catch this, but this was a case of https://docs.astral.sh/ruff/rules/function-uses-loop-variable/