### PR TITLE
Fix an issue with a positional field with default

### DIFF
--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -81,7 +81,7 @@ def _create_parser(tp: Type[Dataclass]) -> ArgumentParser:
                 parser.add_argument(
                     argument_name,
                     choices=get_args(field.type),
-                    default=argparse.SUPPRESS,
+                    default=field.default if positional and field_has_default else argparse.SUPPRESS,
                     help=f"Override field {field.name}.",
                     type=type(get_args(field.type)[0]),
                     **kwargs,
@@ -130,7 +130,7 @@ def _create_parser(tp: Type[Dataclass]) -> ArgumentParser:
             parser.add_argument(
                 argument_name,
                 choices=list(field.type),
-                default=argparse.SUPPRESS,
+                default=field.default if positional and field_has_default else argparse.SUPPRESS,
                 help=f"Override field {field.name}.",
                 type=lambda x: field.type[x],
                 **kwargs,

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -213,3 +213,15 @@ class TestIgnoreArg:
 
         with raises(TypeError):
             parse(TConfig, [])
+
+
+class TestPositional:
+    @dataclass
+    class Config:
+        a: Literal["a", "b"] = field(default="a", metadata={"positional": True})
+        z: str = "dummy"
+
+    def test_ignore_default(self):
+        config = parse(self.Config, [])
+        assert config.a == "a"
+        assert config.z == "dummy"


### PR DESCRIPTION
Before, the test case would result in

```
error: argument a: invalid choice: '==SUPPRESS==' (choose from 'a', 'b')
```