### PR TITLE
fix default args if none are provided

### DIFF
--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -35,7 +35,7 @@ Dataclass = TypeVar("Dataclass", bound=ADataclass)
 
 def parse(tp: Type[Dataclass], args: Optional[list[str]] = None) -> Dataclass:
     if args is None:
-        args = sys.argv
+        args = sys.argv[1:]
     namespace = _create_parser(tp).parse_args(args)
     return tp(**namespace.__dict__)
 

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -34,8 +34,6 @@ Dataclass = TypeVar("Dataclass", bound=ADataclass)
 
 
 def parse(tp: Type[Dataclass], args: Optional[list[str]] = None) -> Dataclass:
-    if args is None:
-        args = sys.argv[1:]
     namespace = _create_parser(tp).parse_args(args)
     return tp(**namespace.__dict__)
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,3 +1,4 @@
+import sys
 from dataclasses import dataclass, field
 from enum import Enum
 from json import loads
@@ -195,4 +196,33 @@ class TestPositional:
     def test_ignore_default(self):
         config = parse(self.Config, [])
         assert config.a == "a"
+        assert config.z == "dummy"
+
+
+class TestSysArgv:
+    @dataclass
+    class Config:
+        positional: str = field(default="positional", metadata=dict(positional=True))
+        a: int = 5
+        z: str = "dummy"
+
+    def test_empty_argv(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["name_of_program"])
+        config = parse(self.Config)
+        assert config.positional == "positional"
+        assert config.a == 5
+        assert config.z == "dummy"
+
+    def test_non_empty_argv(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["name_of_program", "--a", "3"])
+        config = parse(self.Config)
+        assert config.positional == "positional"
+        assert config.a == 3
+        assert config.z == "dummy"
+
+    def test_with_positional_argv(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["name_of_program", "--a", "3", "positional_value"])
+        config = parse(self.Config)
+        assert config.positional == "positional_value"
+        assert config.a == 3
         assert config.z == "dummy"


### PR DESCRIPTION
# Context
The first entry in sys.argv is actually the name of the program.
Right now we are providing a list of arguments in all our tests, but when we are using positional arguments

# How this was verified
I am mocking sys.argv in the unit tests and with this change the behavior is as expected