### PR TITLE
allow kwargs configuration for argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ as keyword arguments to the `parse` function. For example:
 ```python
 config = parse(Config, prog="myprogram", allow_abbrev=False)
 ```
-will disable abbreviations for long options and set the program name to `myprogram` in help messages.
+will disable abbreviations for long options and set the program name to `myprogram` in help messages. For an extensive list of accepted arguments, see [the argparse docs](https://docs.python.org/3/library/argparse.html#argumentparser-objects).
 
 ## Supported Types
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ or
 entrypoint --number 42 --some-string abcd
 ```
 
-## argparse settings
+## ArgumentParser arguments
 
 It's possible to pass additional arguments to the underlying `argparse.ArgumentParser` instance by providing them
 as keyword arguments to the `parse` function. For example:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ or
 entrypoint --number 42 --some-string abcd
 ```
 
+## argparse settings
+
+It's possible to pass additional arguments to the underlying `argparse.ArgumentParser` instance by providing them
+as keyword arguments to the `parse` function. For example:
+
+```python
+config = parse(Config, prog="myprogram", allow_abbrev=False)
+```
+will disable abbreviations for long options and set the program name to `myprogram` in help messages.
+
 ## Supported Types
 
 The base types are supported: `int`, `float`, `str`, `bool`, as well as:

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -33,8 +33,8 @@ class ADataclass(Protocol):
 Dataclass = TypeVar("Dataclass", bound=ADataclass)
 
 
-def parse(tp: Type[Dataclass], args: Optional[list[str]] = None) -> Dataclass:
-    namespace = _create_parser(tp).parse_args(args)
+def parse(tp: Type[Dataclass], args: Optional[list[str]] = None, **kwargs: Any) -> Dataclass:
+    namespace = _create_parser(tp, **kwargs).parse_args(args)
     return tp(**namespace.__dict__)
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -240,9 +240,8 @@ class TestKwargs:
         assert config.a == 1
         assert config.z == "2"
 
-    def test_with_kwargs(self, monkeypatch):
-        monkeypatch.setattr(sys, "argv", ["name_of_program"])
-        config = parse(self.Config, allow_abbrev=False)
+    def test_with_kwargs(self):
+        config = parse(self.Config, [], allow_abbrev=False)
         assert config.a == 5
         assert config.z == "dummy"
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -241,7 +241,7 @@ class TestKwargs:
         assert config.z == "2"
 
     def test_with_kwargs(self):
-        config = parse(self.Config, [], allow_abbrev=False)
+        config = parse(self.Config, None, allow_abbrev=False)
         assert config.a == 5
         assert config.z == "dummy"
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -236,9 +236,9 @@ class TestKwargs:
         z: str = "dummy"
 
     def test_with_args_and_kwargs(self):
-        config = parse(self.Config, ["--a", "1", "--z", "2"], prog_name="pydargs")
+        config = parse(self.Config, ["--a", "1", "--z", "2"], prog="pydargs")
         assert config.a == 1
-        assert config.z == "dummy"
+        assert config.z == "2"
 
     def test_with_kwargs(self, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["name_of_program"])
@@ -250,7 +250,7 @@ class TestKwargs:
         config = parse(self.Config, ["--so", "something_else"])
         assert config.some_long_argument == "something_else"
         assert config.a == 5
-        assert config.z == "2"
+        assert config.z == "dummy"
 
     def test_disallow_abbrev(self, capsys):
         with raises(SystemExit):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -241,7 +241,7 @@ class TestKwargs:
         assert config.z == "2"
 
     def test_with_kwargs(self):
-        config = parse(self.Config, None, allow_abbrev=False)
+        config = parse(self.Config, allow_abbrev=False)
         assert config.a == 5
         assert config.z == "dummy"
 


### PR DESCRIPTION
# Context
I want to be able to disable abbreviations. 
By passing the kwargs to the ArgumentParser we can configure the argparse as we wish.

# How was this verified
Added unit test to verify one of the kwargs is functioning after passing it to the `parse` function