### PR TITLE
Implement recursive dataclass parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ config:
 
 Please be aware of the following:
 - The default (factory) of fields with a dataclass type is ignored by pydargs, which may yield unexpected results.
-  E.g., in the example above, `config: Config = field(default_factory=lambda: Config(field_b="def"))` will not result in a default of "def" for field_b when parsed by pydargs. 
+  E.g., in the example above, `config: Config = field(default_factory=lambda: Config(field_b="def"))` will not result in a default of "def" for field_b when parsed by pydargs.
   Instead, set `field_b: str = "def"` in the definition of `Config`.
   If you must add a default, for example for instantiating your dataclass elsewhere, do `config: Config = field(default_factory=Config)`, assuming that all fields in `Config` have a default.
 - Nested dataclasses can not be positional (although _fields of_ the nested dataclass can be).

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ optional arguments:
 Dataclasses may be nested; the type of a dataclass field may be another dataclass type:
 
 ```python
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 @dataclass
 class Config:

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ config:
 
 Please be aware of the following:
 - The default (factory) of fields with a dataclass type is ignored by pydargs, which may yield unexpected results.
-  If you must add a default, do `field_name: NestedClass = field(default_factory: NestedClass)`.
+  E.g., in the example above, `config: Config = field(default_factory=lambda: Config(field_b="def"))` will not result in a default of "def" for field_b when parsed by pydargs. 
+  Instead, set `field_b: str = "def"` in the definition of `Config`.
+  If you must add a default, for example for instantiating your dataclass elsewhere, do `config: Config = field(default_factory=Config)`, assuming that all fields in `Config` have a default.
 - Nested dataclasses can not be positional (although _fields of_ the nested dataclass can be).
 - Argument names must not collide. In the example above, the `Base` class should not contain a field named `config_field_a`.

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -51,13 +51,14 @@ def parse(tp: Type[Dataclass], args: Optional[list[str]] = None, **kwargs: Any) 
 def _create_object(tp: Type[Dataclass], namespace: Namespace, prefix: str = "") -> Dataclass:
     for field in fields(tp):
         if hasattr(field.type, "__dataclass_fields__"):
+            # Create nested dataclass object
             setattr(
                 namespace,
                 prefix + field.name,
                 _create_object(field.type, namespace, prefix=f"{prefix}{field.name}_"),
             )
     args = {key[len(prefix) :]: value for key, value in namespace.__dict__.items() if key.startswith(prefix)}
-    for key in args.keys():
+    for key in args.keys():  # Remove used keys from the namespace
         delattr(namespace, prefix + key)
     return tp(**args)
 

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -51,11 +51,11 @@ def parse(tp: Type[Dataclass], args: Optional[list[str]] = None, **kwargs: Any) 
 def _create_object(tp: Type[Dataclass], namespace: Namespace, prefix: str = "") -> Dataclass:
     for field in fields(tp):
         if hasattr(field.type, "__dataclass_fields__"):
-            if hasattr(namespace, prefix + field.name):
-                obj = field.type(**getattr(namespace, prefix + field.name))
-            else:
-                obj = _create_object(field.type, namespace, prefix=f"{prefix}{field.name}_")
-            setattr(namespace, prefix + field.name, obj)
+            setattr(
+                namespace,
+                prefix + field.name,
+                _create_object(field.type, namespace, prefix=f"{prefix}{field.name}_"),
+            )
     args = {key[len(prefix) :]: value for key, value in namespace.__dict__.items() if key.startswith(prefix)}
     for key in args.keys():
         delattr(namespace, prefix + key)

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -144,7 +144,6 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
             if field.default_factory is not None and field.default_factory != field.type:
                 warn(f"Non-standard default of field {field.name} is ignored by pydargs.", UserWarning)
             _add_arguments(parser, field.type, prefix=f"{prefix}{field.name}_")
-            argument_kwargs["required"] = False
         elif field.type in (date, datetime):
             parser_or_group.add_argument(
                 *arguments,

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -70,7 +70,7 @@ def _create_parser(tp: Type[Dataclass], **kwargs: Any) -> ArgumentParser:
 
 
 def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = "") -> ArgumentParser:
-    parser_or_group = parser.add_argument_group(prefix.strip("_")) if len(prefix) else parser
+    parser_or_group = parser.add_argument_group(prefix.strip("_")) if prefix else parser
     for field in fields(tp):
         if field.metadata.get("ignore_arg", False):
             continue
@@ -144,6 +144,7 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
                 raise ValueError("Dataclasses may not be positional arguments.")
             if field.default_factory is not None and field.default_factory != field.type:
                 warn(f"Non-standard default of field {field.name} is ignored by pydargs.", UserWarning)
+            # Recursively add arguments for the nested dataclasses
             _add_arguments(parser, field.type, prefix=f"{prefix}{field.name}_")
         elif field.type in (date, datetime):
             parser_or_group.add_argument(

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -60,7 +60,8 @@ def _create_object(tp: Type[Dataclass], namespace: Namespace, prefix: str = "") 
                 _create_object(field.type, namespace, prefix=f"{prefix}{field.name}_"),
             )
     args = {key[len(prefix) :]: value for key, value in namespace.__dict__.items() if key.startswith(prefix)}
-    for key in args.keys():  # Remove used keys from the namespace
+    # Remove the keys used so far from the namespace, to prevent clutter when creating a parent object.
+    for key in args.keys():
         delattr(namespace, prefix + key)
     return tp(**args)
 

--- a/tests/test_recursive.py
+++ b/tests/test_recursive.py
@@ -1,0 +1,253 @@
+from argparse import ArgumentError
+from dataclasses import dataclass, field
+
+from pytest import mark, raises, warns
+
+from pydargs import parse
+
+
+@dataclass
+class SubConfig:
+    a: int = 42
+    b: str = field(default="abc", metadata=dict(help="a string"))
+
+
+@dataclass
+class SubConfigWithRequiredField:
+    a: int
+    b: str = "abc"
+
+
+@dataclass
+class SubConfigWithPositional:
+    a: int = field(default=42, metadata=dict(positional=True))
+    b: str = "abc"
+
+
+@dataclass
+class NestedSub:
+    a: int = 42
+    b: SubConfig = field(default_factory=SubConfig)
+    c: str = "abc"
+
+
+class TestParseSubConfig:
+    @dataclass
+    class Config:
+        mode: str = field(metadata=dict(positional=True))
+        sub: SubConfig = field(default_factory=SubConfig)
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    @mark.parametrize(
+        "help_string",
+        ["usage: prog [-h] [--sub-a SUB_A] [--sub-b SUB_B]", "sub:", "--sub-b SUB_B      a string (default: abc)"],
+    )
+    def test_help(self, capsys, help_string: str):
+        with raises(SystemExit):
+            parse(self.Config, ["--help"], prog="prog")  # type: ignore
+        captured = capsys.readouterr()
+        assert help_string in captured.out.replace("\n", "")
+
+    def test_parse(self, recwarn):
+        config = parse(self.Config, ["mode"])
+        assert len(recwarn) == 0
+        assert config.mode == "mode"
+        assert config.sub.a == 42
+        assert config.sub.b == "abc"
+        assert config.flag is False
+
+    def test_flag(self):
+        config = parse(self.Config, ["mode", "--flag"])
+        assert config.mode == "mode"
+        assert config.sub.a == 42
+        assert config.sub.b == "abc"
+        assert config.flag is True
+
+    def test_set_sub(self):
+        config = parse(self.Config, ["mode", "--sub-a", "1"])
+        assert config.mode == "mode"
+        assert config.sub.a == 1
+        assert config.sub.b == "abc"
+        assert config.flag is False
+
+
+class TestSubConfigCollision:
+    @dataclass
+    class Config:
+        mode: str = field(metadata=dict(positional=True))
+        sub: SubConfig = field(default_factory=SubConfig)
+        sub_a: float = field(default=1.0)
+
+    def test_parse(self):
+        with raises(ArgumentError):
+            parse(self.Config, ["mode"])
+
+
+class TestWarnNonStandardDefault:
+    @dataclass
+    class Config:
+        mode: str = field(metadata=dict(positional=True))
+        sub: SubConfig = field(default_factory=lambda: SubConfig(a=1))
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    def test_warning(self):
+        with warns(UserWarning):
+            parse(self.Config, ["mode"])
+
+
+class TestParseRequiredSubConfig:
+    @dataclass
+    class Config:
+        mode: str = field(metadata=dict(positional=True))
+        sub: SubConfig = field()
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    def test_parse(self):
+        config = parse(self.Config, ["mode"])
+        assert config.mode == "mode"
+        assert config.sub.a == 42
+        assert config.sub.b == "abc"
+        assert config.flag is False
+
+    def test_flag(self):
+        config = parse(self.Config, ["mode", "--flag"])
+        assert config.mode == "mode"
+        assert config.sub.a == 42
+        assert config.sub.b == "abc"
+        assert config.flag is True
+
+    def test_set_sub(self):
+        config = parse(self.Config, ["mode", "--sub-a", "1"])
+        assert config.mode == "mode"
+        assert config.sub.a == 1
+        assert config.sub.b == "abc"
+        assert config.flag is False
+
+
+class TestParseSubConfigWithRequiredField:
+    @dataclass
+    class Config:
+        mode: str = field(metadata=dict(positional=True))
+        sub: SubConfigWithRequiredField
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    def test_parse_required(self, capsys):
+        with raises(SystemExit):
+            parse(self.Config, ["mode"])
+        captured = capsys.readouterr()
+        assert "the following arguments are required: --sub-a" in captured.err
+
+    def test_flag(self):
+        config = parse(self.Config, ["mode", "--sub-a", "1", "--flag"])
+        assert config.mode == "mode"
+        assert config.sub.a == 1
+        assert config.sub.b == "abc"
+        assert config.flag is True
+
+    def test_set_sub(self):
+        config = parse(self.Config, ["mode", "--sub-a", "1", "--sub-b", "def"])
+        assert config.mode == "mode"
+        assert config.sub.a == 1
+        assert config.sub.b == "def"
+        assert config.flag is False
+
+
+class TestParseSubConfigWithPositional:
+    @dataclass
+    class Config:
+        mode: str = field(metadata=dict(positional=True))
+        sub: SubConfigWithPositional = field(default_factory=SubConfigWithPositional)
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    def test_help(self, capsys):
+        with raises(SystemExit):
+            parse(self.Config, ["--help"], prog="prog")  # type: ignore
+        captured = capsys.readouterr()
+        assert "mode [sub_a]" in captured.out
+
+    def test_parse(self):
+        config = parse(self.Config, ["mode"])
+        assert config.mode == "mode"
+        assert config.sub.a == 42
+        assert config.sub.b == "abc"
+        assert config.flag is False
+
+    def test_flag(self):
+        config = parse(self.Config, ["mode", "1", "--flag"])
+        assert config.mode == "mode"
+        assert config.sub.a == 1
+        assert config.sub.b == "abc"
+        assert config.flag is True
+
+    def test_set_sub(self):
+        config = parse(
+            self.Config,
+            ["mode", "1", "--sub-b", "def"],
+        )
+        assert config.mode == "mode"
+        assert config.sub.a == 1
+        assert config.sub.b == "def"
+        assert config.flag is False
+
+
+class TestParsePositionalSubConfig:
+    @dataclass
+    class Config:
+        mode: str = field(metadata=dict(positional=True))
+        sub: SubConfig = field(default_factory=SubConfig, metadata=dict(positional=True))
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    def test_parse(self):
+        with raises(ValueError):
+            parse(self.Config, ["mode"])
+
+
+class TestParseNestedSubConfig:
+    @dataclass
+    class Config:
+        mode: str = field(metadata=dict(positional=True))
+        sub: NestedSub = field(default_factory=NestedSub)
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    @mark.parametrize(
+        "help_string",
+        [
+            "usage: prog [-h] [--sub-a SUB_A] [--sub-b-a SUB_B_A]",
+            "sub_b:",
+            "--sub-b-b SUB_B_B  a string (default: abc)\n",
+        ],
+    )
+    def test_help(self, capsys, help_string: str):
+        with raises(SystemExit):
+            parse(self.Config, ["--help"], prog="prog")  # type: ignore
+        captured = capsys.readouterr()
+        assert help_string in captured.out
+
+    def test_parse(self):
+        config = parse(self.Config, ["mode"])
+        assert config.mode == "mode"
+        assert config.sub.a == 42
+        assert config.sub.b.a == 42
+        assert config.sub.b.b == "abc"
+        assert config.sub.c == "abc"
+        assert config.flag is False
+
+    def test_sub(self):
+        config = parse(self.Config, ["mode", "--sub-a", "1", "--flag"])
+        assert config.mode == "mode"
+        assert config.sub.a == 1
+        assert config.sub.b.a == 42
+        assert config.sub.b.b == "abc"
+        assert config.sub.c == "abc"
+        assert config.flag is True
+
+    def test_sub_sub(self):
+        config = parse(
+            self.Config,
+            ["mode", "--sub-a", "1", "--sub-b-a", "21", "--sub-b-b", "def"],
+        )
+        assert config.sub.a == 1
+        assert config.sub.b.a == 21
+        assert config.sub.b.b == "def"
+        assert config.sub.c == "abc"
+        assert config.flag is False


### PR DESCRIPTION
This allows fields of the dataclass to be other dataclasses.

This PR closes #15 and replaces #22 