### PR TITLE
Clean up type function renaming

### DIFF
--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -113,7 +113,7 @@ def _create_parser(tp: Type[Dataclass], **kwargs: Any) -> ArgumentParser:
             elif origin in UNION_TYPES:
                 parser.add_argument(
                     *arguments,
-                    type=named_partial(_parse_union, name=repr(field.type), union_type=field.type),
+                    type=named_partial(_parse_union, _display_name=repr(field.type), union_type=field.type),
                     **argument_kwargs,
                 )
             else:
@@ -123,9 +123,9 @@ def _create_parser(tp: Type[Dataclass], **kwargs: Any) -> ArgumentParser:
                 *arguments,
                 type=named_partial(
                     _parse_datetime,
+                    _display_name=str(field.type),
                     is_date=field.type is date,
                     date_format=field.metadata.get("date_format"),
-                    name=str(field.type),
                 ),
                 **argument_kwargs,
             )
@@ -155,7 +155,7 @@ def _create_parser(tp: Type[Dataclass], **kwargs: Any) -> ArgumentParser:
             encoding = field.metadata.get("encoding", "utf-8")
             parser.add_argument(
                 *arguments,
-                type=named_partial(field.type, encoding=encoding, name=encoding),
+                type=named_partial(field.type, _display_name=encoding, encoding=encoding),
                 **argument_kwargs,
             )
         else:

--- a/src/pydargs/utils.py
+++ b/src/pydargs/utils.py
@@ -1,0 +1,20 @@
+from functools import partial
+from typing import Any, Callable, TypeVar
+
+Fct = TypeVar("Fct")
+
+
+def named_partial(func: Callable[..., Any], *, name: str, **kwargs) -> Callable[[str], Any]:
+    # Wrapper around partial to give it a name, for argparse to provide meaningful messages
+    result = partial(func, **kwargs)
+    setattr(result, "__name__", name)
+    return result
+
+
+def rename(name: str) -> Callable[[Fct], Fct]:
+    # Function decorator to give a function a specific name, for argparse to provide meaningful messages
+    def wrapper(f: Fct) -> Fct:
+        setattr(f, "__name__", name)
+        return f
+
+    return wrapper

--- a/src/pydargs/utils.py
+++ b/src/pydargs/utils.py
@@ -4,10 +4,10 @@ from typing import Any, Callable, TypeVar
 Fct = TypeVar("Fct")
 
 
-def named_partial(func: Callable[..., Any], *, name: str, **kwargs) -> Callable[[str], Any]:
+def named_partial(func: Callable[..., Any], *, _display_name: str, **kwargs) -> Callable[[str], Any]:
     # Wrapper around partial to give it a name, for argparse to provide meaningful messages
     result = partial(func, **kwargs)
-    setattr(result, "__name__", name)
+    setattr(result, "__name__", _display_name)
     return result
 
 


### PR DESCRIPTION
Create two functions that rename type converters, in order to allow argparse to print a useful error message, and put them in `utils.py`