### PR TITLE
Allow overriding fields by envvars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,7 +161,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # PyEnv
 .python-version

--- a/README.md
+++ b/README.md
@@ -192,13 +192,23 @@ optional arguments:
   --an-integer INT
 ```
 
-## `allow_envvar_override`
+## `envvar_override`
 
-To override the value of a field by setting an environment variable, use field metadata `allow_envvar_override`.
-Either by setting `allow_envvar_override=True` or to the name of the envvar to use i.e. `allow_envvar_override="MY_ENVVAR"`.
-In the latter, `"MY_ENVVAR"` will be used to look up the environment variable.
+To override the value of a field by setting an environment variable, use field metadata `envvar_override`.
+Either by setting `envvar_override=True` or to the name of the envvar to use i.e. `envvar_override="MY_ENVVAR"`.
+
+```python
+@dataclass
+class Config:
+    # Can be overridden by setting envvar "EXAMPLE"
+    example: str = field(metadata=dict(envvar_override=True))
+    # Can be overridden by setting envvar "MY_ENVVAR"
+    other_example: int = field(metadata=dict(envvar_override="MY_ENVVAR"))
+```
 
 When the argument is also provided via the command line, the environment variable is ignored.
+We do not allow overriding positional arguments via environment variables.
+
 
 ## Nested Dataclasses
 

--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ class Config:
 ```
 
 When the argument is also provided via the command line, the environment variable is ignored.
-We do not allow overriding positional arguments via environment variables.
-
+We do not support overriding positional arguments via environment variables.
+We do not support overriding collection types (list, tuple, set, etc.) via environment variables.
 
 ## Nested Dataclasses
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ optional arguments:
   --an-integer INT
 ```
 
+## `allow_envvar_override`
+
+To override the value of a field by setting an environment variable, use field metadata `allow_envvar_override`.
+Either by setting `allow_envvar_override=True` or to the name of the envvar to use i.e. `allow_envvar_override="MY_ENVVAR"`.
+In the latter, `"MY_ENVVAR"` will be used to look up the environment variable.
+
+When the argument is also provided via the command line, the environment variable is ignored.
+
 ## Nested Dataclasses
 
 Dataclasses may be nested; the type of a dataclass field may be another dataclass type:

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -1,4 +1,5 @@
 import sys
+import os
 from argparse import ArgumentParser, BooleanOptionalAction, Namespace, SUPPRESS
 from collections.abc import Sequence
 from dataclasses import MISSING, dataclass, fields
@@ -81,14 +82,31 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
         argument_kwargs: dict[str, Any] = dict()
         field_has_default = field.default is not MISSING or field.default_factory is not MISSING
         argument_kwargs["help"] = field.metadata.get("help", "")
+        positional = field.metadata.get("positional", False)
+        short_option = field.metadata.get("short_option")
+        override_by_envvar = field.metadata.get("allow_envvar_override", False)
+
+        if override_by_envvar and positional:
+            raise ValueError("Positional arguments cannot be overridden by envvars.")
+
+        if override_by_envvar:
+            if isinstance(override_by_envvar, str):
+                envvar_name = override_by_envvar
+            else:
+                envvar_name = field.name.upper()
+
+            if value_from_env := os.environ.get(envvar_name):
+                if field.default_factory is not MISSING:
+                    raise ValueError("Overriding default_factory properties by envvars is not supported.")
+                argument_kwargs["default"] = value_from_env
+
         if field.default is not MISSING:
             if len(argument_kwargs["help"]):
                 argument_kwargs["help"] += " "
             argument_kwargs["help"] += f"(default: {field.default})"
         if "metavar" in field.metadata:
             argument_kwargs["metavar"] = field.metadata["metavar"]
-        positional = field.metadata.get("positional", False)
-        short_option = field.metadata.get("short_option")
+
         if positional:
             if short_option:
                 raise ValueError("Short options are not supported for positional arguments.")

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -84,7 +84,7 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
         argument_kwargs["help"] = field.metadata.get("help", "")
         positional = field.metadata.get("positional", False)
         short_option = field.metadata.get("short_option")
-        override_by_envvar = field.metadata.get("allow_envvar_override", False)
+        override_by_envvar = field.metadata.get("envvar_override", False)
 
         if override_by_envvar and positional:
             raise ValueError("Positional arguments cannot be overridden by envvars.")

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -96,8 +96,9 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
                 envvar_name = field.name.upper()
 
             if value_from_env := os.environ.get(envvar_name):
-                if field.default_factory is not MISSING:
-                    raise ValueError("Overriding default_factory properties by envvars is not supported.")
+                origin = get_origin(field.type)
+                if any(origin is cls for cls in (Sequence, list, tuple, set)):
+                    raise TypeError("Overriding default_factory properties by envvars is not supported.")
                 argument_kwargs["default"] = value_from_env
 
         if field.default is not MISSING:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -360,13 +360,13 @@ class SecretStr(str):
 class TestEnvironmentVariables:
     @dataclass
     class Config:
-        my_property: str = field(default="default_value", metadata=dict(allow_envvar_override=True))
-        a: str = field(default="default_value", metadata=dict(allow_envvar_override="OTHER_ENVVAR"))
+        my_property: str = field(default="default_value", metadata=dict(envvar_override=True))
+        a: str = field(default="default_value", metadata=dict(envvar_override="OTHER_ENVVAR"))
         z: str = "dummy"
 
     @dataclass
     class ConfigWithSecret:
-        my_property: SecretStr = field(default=SecretStr("default_value"), metadata=dict(allow_envvar_override=True))
+        my_property: SecretStr = field(default=SecretStr("default_value"), metadata=dict(envvar_override=True))
         z: str = "dummy"
 
     def test_default(self):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -341,3 +341,76 @@ class TestKwargs:
             parse(self.Config, ["--so", "something_else"], allow_abbrev=False)
         captured = capsys.readouterr()
         assert "error: unrecognized arguments: --so something_else" in captured.err
+
+
+class SecretStr(str):
+    def __init__(self, value: str):
+        self._secret_value = value
+
+    def __str__(self):
+        return "*********"
+
+    def __repr__(self):
+        return self.__str__()
+
+    def get_secret_value(self):
+        return self._secret_value
+
+
+class TestEnvironmentVariables:
+    @dataclass
+    class Config:
+        my_property: str = field(default="default_value", metadata=dict(allow_envvar_override=True))
+        a: str = field(default="default_value", metadata=dict(allow_envvar_override="OTHER_ENVVAR"))
+        z: str = "dummy"
+
+    @dataclass
+    class ConfigWithSecret:
+        my_property: SecretStr = field(default=SecretStr("default_value"), metadata=dict(allow_envvar_override=True))
+        z: str = "dummy"
+
+    def test_default(self):
+        config = parse(self.Config)
+        assert config.my_property == "default_value"
+        assert config.z == "dummy"
+
+    def test_override(self, monkeypatch):
+        monkeypatch.setenv("MY_PROPERTY", "new_value")
+        config = parse(self.Config)
+        assert config.my_property == "new_value"
+        assert config.z == "dummy"
+
+    def test_double_override(self, monkeypatch):
+        monkeypatch.setenv("MY_PROPERTY", "new_value")
+        config = parse(self.Config, ["--my-property", "another_value"])
+        assert config.my_property == "another_value"
+        assert config.z == "dummy"
+
+    def test_override_by_different_key(self, monkeypatch):
+        monkeypatch.setenv("OTHER_ENVVAR", "new_value")
+        config = parse(self.Config)
+        assert config.my_property == "default_value"
+        assert config.a == "new_value"
+        assert config.z == "dummy"
+
+    def test_secret_envvar(self, monkeypatch, capsys):
+        monkeypatch.setenv("MY_PROPERTY", "my_secret")
+        config = parse(self.ConfigWithSecret)
+        assert str(config.my_property) == "*********"
+        assert config.my_property.get_secret_value() == "my_secret"
+        assert config.z == "dummy"
+
+        # Make sure the secret is not printed
+        print(config)
+        captured = capsys.readouterr()
+        assert "my_secret" not in captured.out
+
+    def test_secret_envvar_help(self, monkeypatch, capsys):
+        monkeypatch.setenv("MY_PROPERTY", "my_secret")
+
+        with raises(SystemExit):
+            parse(self.ConfigWithSecret, ["--help"])
+
+        # Make sure the secret is not printed
+        captured = capsys.readouterr()
+        assert "my_secret" not in captured.out


### PR DESCRIPTION
This allows users to override the default of a field when the `allow_envvar_override` metadata is configured.

Because we override the default, the argument provided via the cli is still leading. This is documented.

Also added a simplified implementation of [SecretStr](https://docs.pydantic.dev/latest/examples/secrets/) to verify the typecasting goes well when the default is supplied from the envvar. This is a common usecase for envvars, so I think it's valuable to have.

Using pydantic dataclasses does not provide this functionality out of the box. Apparently, this is only supported for BaseSettings.