### PR TITLE
Fix dataclass typevar

### DIFF
--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -1,11 +1,12 @@
 import sys
 from argparse import ArgumentParser, BooleanOptionalAction, Namespace, SUPPRESS
 from collections.abc import Sequence
-from dataclasses import MISSING, dataclass, fields
+from dataclasses import MISSING, fields
 from datetime import date, datetime
 from enum import Enum
 from typing import (
     Any,
+    ClassVar,
     Literal,
     Optional,
     Protocol,
@@ -27,12 +28,11 @@ if sys.version_info >= (3, 10):
     UNION_TYPES.add(UnionType)
 
 
-@dataclass
-class ADataclass(Protocol):
-    ...
+class DataClassProtocol(Protocol):
+    __dataclass_fields__: ClassVar[dict]
 
 
-Dataclass = TypeVar("Dataclass", bound=ADataclass)
+Dataclass = TypeVar("Dataclass", bound=DataClassProtocol)
 
 
 def parse(tp: Type[Dataclass], args: Optional[list[str]] = None, **kwargs: Any) -> Dataclass:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -10,7 +10,7 @@ from pydargs import parse
 
 
 class TestParseCustomParser:
-    def test_parser_optional(self):
+    def test_parser_optional(self) -> None:
         @dataclass
         class TConfig:
             arg: Optional[list[int]] = field(default=None, metadata=dict(parser=loads))
@@ -24,7 +24,7 @@ class TestParseCustomParser:
         t = parse(TConfig, ["--arg", '{"1": 2}'])
         assert t.arg == {"1": 2}
 
-    def test_parser_required(self, capsys):
+    def test_parser_required(self, capsys) -> None:
         @dataclass
         class TConfig:
             arg: list[int] = field(metadata=dict(parser=loads))
@@ -37,7 +37,7 @@ class TestParseCustomParser:
         t = parse(TConfig, ["--arg", "[1, 2]"])
         assert t.arg == [1, 2]
 
-    def test_parser_invalid(self, capsys):
+    def test_parser_invalid(self, capsys) -> None:
         @dataclass
         class TConfig:
             arg: list[int] = field(metadata=dict(parser=loads))
@@ -49,7 +49,7 @@ class TestParseCustomParser:
 
 
 class TestParseChoices:
-    def test_enum(self, capsys):
+    def test_enum(self, capsys) -> None:
         class AnEnum(Enum):
             one = 1
             two = 2
@@ -67,7 +67,7 @@ class TestParseChoices:
         t = parse(TConfig, ["--an-enum", "one"])
         assert t.an_enum == AnEnum.one
 
-    def test_str_enum(self, capsys):
+    def test_str_enum(self, capsys) -> None:
         class AnEnum(str, Enum):
             one = "one"
             two = "two"
@@ -91,7 +91,7 @@ class TestParseChoices:
         assert t.an_enum == AnEnum.one
         assert t.another_enum == AnEnum.two
 
-    def test_str_literal(self, capsys):
+    def test_str_literal(self, capsys) -> None:
         @dataclass
         class TConfig:
             a_literal: Literal["x", "y"] = "x"
@@ -107,7 +107,7 @@ class TestParseChoices:
         captured = capsys.readouterr()
         assert "error: argument --a-literal: invalid choice: 'z'" in captured.err
 
-    def test_int_literal(self, capsys):
+    def test_int_literal(self, capsys) -> None:
         @dataclass
         class TConfig:
             a_literal: Literal[1, 2] = 1
@@ -123,7 +123,7 @@ class TestParseChoices:
         captured = capsys.readouterr()
         assert "error: argument --a-literal: invalid choice: 3" in captured.err
 
-    def test_fail_mixed_types(self):
+    def test_fail_mixed_types(self) -> None:
         @dataclass
         class TConfig:
             a_literal: Literal[1, "2"] = 1
@@ -133,7 +133,7 @@ class TestParseChoices:
 
 
 class TestNotImplemented:
-    def test_set(self):
+    def test_set(self) -> None:
         @dataclass
         class TConfig:
             a: set[int]
@@ -141,7 +141,7 @@ class TestNotImplemented:
         with raises(NotImplementedError):
             parse(TConfig, ["--a", "1", "1", "2"])
 
-    def test_tuple(self):
+    def test_tuple(self) -> None:
         @dataclass
         class TConfig:
             a: tuple[str]
@@ -158,26 +158,26 @@ class TestIgnoreArg:
         c: bool = field(default=False, metadata=dict(ignore_arg=False, as_flags=True))
         z: str = "dummy"
 
-    def test_ignore_default(self):
+    def test_ignore_default(self) -> None:
         config = parse(self.Config, [])
         assert config.a == 5
         assert config.b == "something"
         assert config.c is False
         assert config.z == "dummy"
 
-    def test_ignore_valid(self):
+    def test_ignore_valid(self) -> None:
         config = parse(self.Config, ["--a", "1", "--c"])
         assert config.a == 1
         assert config.b == "something"
         assert config.c is True
 
-    def test_ignore_invalid(self, capsys):
+    def test_ignore_invalid(self, capsys) -> None:
         with raises(SystemExit):
             parse(self.Config, ["--b", "2"])
         captured = capsys.readouterr()
         assert "error: unrecognized arguments: --b 2" in captured.err
 
-    def test_ignore_invalid_no_default(self, capsys):
+    def test_ignore_invalid_no_default(self, capsys) -> None:
         @dataclass
         class TConfig:
             a: str = field(metadata={"ignore_arg": True})
@@ -193,18 +193,18 @@ class TestPositional:
         a: Literal["a", "b"] = field(default="a", metadata={"positional": True})
         z: str = field(default="dummy")
 
-    def test_ignore_default(self):
+    def test_ignore_default(self) -> None:
         config = parse(self.Config, [])
         assert config.a == "a"
         assert config.z == "dummy"
 
     @mark.parametrize("args", [["b", "--z", "Z"], ["--z", "Z", "b"]])
-    def test_order(self, args: list[str]):
+    def test_order(self, args: list[str]) -> None:
         config = parse(self.Config, args)  # type: ignore
         assert config.a == "b"
         assert config.z == "Z"
 
-    def test_positional_with_default(self):
+    def test_positional_with_default(self) -> None:
         @dataclass
         class Config:
             positional: int = field(default=123, metadata=dict(positional=True))
@@ -215,7 +215,7 @@ class TestPositional:
         config = parse(Config, [])
         assert config.positional == 123
 
-    def test_positional_with_default_factory(self):
+    def test_positional_with_default_factory(self) -> None:
         @dataclass
         class Config:
             positional: int = field(default_factory=lambda: 123, metadata=dict(positional=True))
@@ -226,7 +226,7 @@ class TestPositional:
         config = parse(Config, [])
         assert config.positional == 123
 
-    def test_default_factory_modification(self):
+    def test_default_factory_modification(self) -> None:
         @dataclass
         class Config:
             positional: list[int] = field(default_factory=lambda: [123], metadata=dict(positional=True))
@@ -238,7 +238,7 @@ class TestPositional:
         config_2 = parse(Config, [])
         assert config_2.positional == [123]
 
-    def test_list_positional(self):
+    def test_list_positional(self) -> None:
         @dataclass
         class Config:
             positional: list[int] = field(default_factory=lambda: [1, 2, 3], metadata=dict(positional=True))
@@ -269,13 +269,13 @@ class TestHelp:
             "  --another-string AS   (default: xyz)",
         ],
     )
-    def test_help(self, capsys, help_string: str):
+    def test_help(self, capsys, help_string: str) -> None:
         with raises(SystemExit):
             parse(self.Config, ["--help"], prog="prog")  # type: ignore
         captured = capsys.readouterr()
         assert help_string in captured.out.replace("\n", "")
 
-    def test_short_option_must_have_dash(self):
+    def test_short_option_must_have_dash(self) -> None:
         @dataclass
         class InvalidConfig:
             an_integer: int = field(metadata={"short_option": "s"})
@@ -291,21 +291,21 @@ class TestSysArgv:
         a: int = 5
         z: str = "dummy"
 
-    def test_empty_argv(self, monkeypatch):
+    def test_empty_argv(self, monkeypatch) -> None:
         monkeypatch.setattr(sys, "argv", ["name_of_program"])
         config = parse(self.Config)
         assert config.positional == "positional"
         assert config.a == 5
         assert config.z == "dummy"
 
-    def test_non_empty_argv(self, monkeypatch):
+    def test_non_empty_argv(self, monkeypatch) -> None:
         monkeypatch.setattr(sys, "argv", ["name_of_program", "--a", "3"])
         config = parse(self.Config)
         assert config.positional == "positional"
         assert config.a == 3
         assert config.z == "dummy"
 
-    def test_with_positional_argv(self, monkeypatch):
+    def test_with_positional_argv(self, monkeypatch) -> None:
         monkeypatch.setattr(sys, "argv", ["name_of_program", "--a", "3", "positional_value"])
         config = parse(self.Config)
         assert config.positional == "positional_value"
@@ -320,23 +320,23 @@ class TestKwargs:
         some_long_argument: str = "something"
         z: str = "dummy"
 
-    def test_with_args_and_kwargs(self):
+    def test_with_args_and_kwargs(self) -> None:
         config = parse(self.Config, ["--a", "1", "--z", "2"], prog="pydargs")
         assert config.a == 1
         assert config.z == "2"
 
-    def test_with_kwargs(self):
+    def test_with_kwargs(self) -> None:
         config = parse(self.Config, allow_abbrev=False)
         assert config.a == 5
         assert config.z == "dummy"
 
-    def test_allow_abbrev(self):
+    def test_allow_abbrev(self) -> None:
         config = parse(self.Config, ["--so", "something_else"])
         assert config.some_long_argument == "something_else"
         assert config.a == 5
         assert config.z == "dummy"
 
-    def test_disallow_abbrev(self, capsys):
+    def test_disallow_abbrev(self, capsys) -> None:
         with raises(SystemExit):
             parse(self.Config, ["--so", "something_else"], allow_abbrev=False)
         captured = capsys.readouterr()

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -27,7 +27,7 @@ class TestPydanticDataclass:
 
         return Config
 
-    def test_instantiate(self, config):
+    def test_instantiate(self, config) -> None:
         c = parse(config, ["1", "--b", "b"])
         assert c.a == 1
         assert c.b == "b"
@@ -36,7 +36,7 @@ class TestPydanticDataclass:
         assert c.e == "e"
         assert c.f == 1
 
-    def test_validation(self, config):
+    def test_validation(self, config) -> None:
         c = parse(config, ["1", "--b", "b", "--c", "1.5"])
         assert c.c == approx(1.5)
 

--- a/tests/test_recursive.py
+++ b/tests/test_recursive.py
@@ -42,13 +42,13 @@ class TestParseSubConfig:
         "help_string",
         ["usage: prog [-h] [--sub-a SUB_A] [--sub-b SUB_B]", "sub:", "--sub-b SUB_B      a string (default: abc)"],
     )
-    def test_help(self, capsys, help_string: str):
+    def test_help(self, capsys, help_string: str) -> None:
         with raises(SystemExit):
             parse(self.Config, ["--help"], prog="prog")  # type: ignore
         captured = capsys.readouterr()
         assert help_string in captured.out.replace("\n", "")
 
-    def test_parse(self, recwarn):
+    def test_parse(self, recwarn) -> None:
         config = parse(self.Config, ["mode"])
         assert len(recwarn) == 0
         assert config.mode == "mode"
@@ -56,14 +56,14 @@ class TestParseSubConfig:
         assert config.sub.b == "abc"
         assert config.flag is False
 
-    def test_flag(self):
+    def test_flag(self) -> None:
         config = parse(self.Config, ["mode", "--flag"])
         assert config.mode == "mode"
         assert config.sub.a == 42
         assert config.sub.b == "abc"
         assert config.flag is True
 
-    def test_set_sub(self):
+    def test_set_sub(self) -> None:
         config = parse(self.Config, ["mode", "--sub-a", "1"])
         assert config.mode == "mode"
         assert config.sub.a == 1
@@ -78,7 +78,7 @@ class TestSubConfigCollision:
         sub: SubConfig = field(default_factory=SubConfig)
         sub_a: float = field(default=1.0)
 
-    def test_parse(self):
+    def test_parse(self) -> None:
         with raises(ArgumentError):
             parse(self.Config, ["mode"])
 
@@ -90,7 +90,7 @@ class TestWarnNonStandardDefault:
         sub: SubConfig = field(default_factory=lambda: SubConfig(a=1))
         flag: bool = field(default=False, metadata=dict(as_flags=True))
 
-    def test_warning(self):
+    def test_warning(self) -> None:
         with warns(UserWarning):
             parse(self.Config, ["mode"])
 
@@ -102,21 +102,21 @@ class TestParseRequiredSubConfig:
         sub: SubConfig = field()
         flag: bool = field(default=False, metadata=dict(as_flags=True))
 
-    def test_parse(self):
+    def test_parse(self) -> None:
         config = parse(self.Config, ["mode"])
         assert config.mode == "mode"
         assert config.sub.a == 42
         assert config.sub.b == "abc"
         assert config.flag is False
 
-    def test_flag(self):
+    def test_flag(self) -> None:
         config = parse(self.Config, ["mode", "--flag"])
         assert config.mode == "mode"
         assert config.sub.a == 42
         assert config.sub.b == "abc"
         assert config.flag is True
 
-    def test_set_sub(self):
+    def test_set_sub(self) -> None:
         config = parse(self.Config, ["mode", "--sub-a", "1"])
         assert config.mode == "mode"
         assert config.sub.a == 1
@@ -131,20 +131,20 @@ class TestParseSubConfigWithRequiredField:
         sub: SubConfigWithRequiredField
         flag: bool = field(default=False, metadata=dict(as_flags=True))
 
-    def test_parse_required(self, capsys):
+    def test_parse_required(self, capsys) -> None:
         with raises(SystemExit):
             parse(self.Config, ["mode"])
         captured = capsys.readouterr()
         assert "the following arguments are required: --sub-a" in captured.err
 
-    def test_flag(self):
+    def test_flag(self) -> None:
         config = parse(self.Config, ["mode", "--sub-a", "1", "--flag"])
         assert config.mode == "mode"
         assert config.sub.a == 1
         assert config.sub.b == "abc"
         assert config.flag is True
 
-    def test_set_sub(self):
+    def test_set_sub(self) -> None:
         config = parse(self.Config, ["mode", "--sub-a", "1", "--sub-b", "def"])
         assert config.mode == "mode"
         assert config.sub.a == 1
@@ -159,27 +159,27 @@ class TestParseSubConfigWithPositional:
         sub: SubConfigWithPositional = field(default_factory=SubConfigWithPositional)
         flag: bool = field(default=False, metadata=dict(as_flags=True))
 
-    def test_help(self, capsys):
+    def test_help(self, capsys) -> None:
         with raises(SystemExit):
             parse(self.Config, ["--help"], prog="prog")  # type: ignore
         captured = capsys.readouterr()
         assert "mode [sub_a]" in captured.out
 
-    def test_parse(self):
+    def test_parse(self) -> None:
         config = parse(self.Config, ["mode"])
         assert config.mode == "mode"
         assert config.sub.a == 42
         assert config.sub.b == "abc"
         assert config.flag is False
 
-    def test_flag(self):
+    def test_flag(self) -> None:
         config = parse(self.Config, ["mode", "1", "--flag"])
         assert config.mode == "mode"
         assert config.sub.a == 1
         assert config.sub.b == "abc"
         assert config.flag is True
 
-    def test_set_sub(self):
+    def test_set_sub(self) -> None:
         config = parse(
             self.Config,
             ["mode", "1", "--sub-b", "def"],
@@ -197,7 +197,7 @@ class TestParsePositionalSubConfig:
         sub: SubConfig = field(default_factory=SubConfig, metadata=dict(positional=True))
         flag: bool = field(default=False, metadata=dict(as_flags=True))
 
-    def test_parse(self):
+    def test_parse(self) -> None:
         with raises(ValueError):
             parse(self.Config, ["mode"])
 
@@ -217,13 +217,13 @@ class TestParseNestedSubConfig:
             "--sub-b-b SUB_B_B  a string (default: abc)\n",
         ],
     )
-    def test_help(self, capsys, help_string: str):
+    def test_help(self, capsys, help_string: str) -> None:
         with raises(SystemExit):
             parse(self.Config, ["--help"], prog="prog")  # type: ignore
         captured = capsys.readouterr()
         assert help_string in captured.out
 
-    def test_parse(self):
+    def test_parse(self) -> None:
         config = parse(self.Config, ["mode"])
         assert config.mode == "mode"
         assert config.sub.a == 42
@@ -232,7 +232,7 @@ class TestParseNestedSubConfig:
         assert config.sub.c == "abc"
         assert config.flag is False
 
-    def test_sub(self):
+    def test_sub(self) -> None:
         config = parse(self.Config, ["mode", "--sub-a", "1", "--flag"])
         assert config.mode == "mode"
         assert config.sub.a == 1
@@ -241,7 +241,7 @@ class TestParseNestedSubConfig:
         assert config.sub.c == "abc"
         assert config.flag is True
 
-    def test_sub_sub(self):
+    def test_sub_sub(self) -> None:
         config = parse(
             self.Config,
             ["mode", "--sub-a", "1", "--sub-b-a", "21", "--sub-b-b", "def"],

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -19,13 +19,13 @@ class TestBase:
         e: str = field(metadata=dict(positional=True), default="e")
         f: int = field(default_factory=lambda: 1)
 
-    def test_a_required(self, capsys):
+    def test_a_required(self, capsys) -> None:
         with raises(SystemExit):
             parse(self.Config, [])
         captured = capsys.readouterr()
         assert "the following arguments are required: a, --b" in captured.err
 
-    def test_default(self):
+    def test_default(self) -> None:
         config = parse(self.Config, ["1", "--b", "b"])
         assert config.a == 1
         assert config.b == "b"
@@ -34,7 +34,7 @@ class TestBase:
         assert config.e == "e"
         assert config.f == 1
 
-    def test_shuffled(self):
+    def test_shuffled(self) -> None:
         config = parse(self.Config, ["--b", "b", "1"])
         assert config.a == 1
         assert config.b == "b"
@@ -43,11 +43,11 @@ class TestBase:
         "args, attr, value",
         [(["--c", "1.23"], "c", 1.23), (["--d", "123"], "d", 123), (["--f", "2"], "f", 2)],
     )
-    def test_args(self, args, attr, value):
+    def test_args(self, args, attr, value) -> None:
         config = parse(self.Config, ["1", "--b", "b"] + args)
         assert getattr(config, attr) == value
 
-    def test_second_positional(self):
+    def test_second_positional(self) -> None:
         config = parse(self.Config, ["1", "f", "--b", "b"])
         assert config.e == "f"
 
@@ -59,17 +59,17 @@ class TestBytes:
         b: bytes = field(default=b"b", metadata=dict(encoding="ascii"))
         z: int = 12
 
-    def test_default(self):
+    def test_default(self) -> None:
         config = parse(self.Config, [])
         assert config.a == b"a"
         assert config.b == b"b"
         assert config.z == 12
 
-    def test_encoding(self):
+    def test_encoding(self) -> None:
         config = parse(self.Config, ["--a", "ꀀ"])
         assert config.a == b"\xea\x80\x80"
 
-    def test_invalid_encoding(self, capsys):
+    def test_invalid_encoding(self, capsys) -> None:
         with raises(SystemExit):
             parse(self.Config, ["--b", "ꀀ"])
         captured = capsys.readouterr()
@@ -86,13 +86,13 @@ class TestList:
         e: Sequence[str] = ("a", "b")
         f: str = "dummy"
 
-    def test_a_required(self, capsys):
+    def test_a_required(self, capsys) -> None:
         with raises(SystemExit):
             parse(self.Config, [])
         captured = capsys.readouterr()
         assert "the following arguments are required: --a" in captured.err
 
-    def test_default(self):
+    def test_default(self) -> None:
         config = parse(self.Config, ["--a", "1"])
         assert config.a == [1]
         assert config.b == []
@@ -100,23 +100,23 @@ class TestList:
         assert config.e == ("a", "b")
         assert config.f == "dummy"
 
-    def test_list_args(self):
+    def test_list_args(self) -> None:
         config = parse(self.Config, ["--a", "1", "--b", "a", "b", "--f", "value"])
         assert config.b == ["a", "b"]
 
-    def test_sequence_args(self):
+    def test_sequence_args(self) -> None:
         config = parse(self.Config, ["--a", "1", "--d", "2.0", "2.5"])
         assert config.d == [2.0, 2.5]
 
-    def test_sequence_args_tuple(self):
+    def test_sequence_args_tuple(self) -> None:
         config = parse(self.Config, ["--a", "1", "--e", "d"])
         assert config.e == ["d"]
 
-    def test_positional_args(self):
+    def test_positional_args(self) -> None:
         config = parse(self.Config, ["x", "y", "--a", "1"])
         assert config.c == ["x", "y"]
 
-    def test_invalid_type(self, capsys):
+    def test_invalid_type(self, capsys) -> None:
         with raises(SystemExit):
             parse(self.Config, ["--a", "1", "--d", "abc"])
         captured = capsys.readouterr()
@@ -133,7 +133,7 @@ class TestUnion:
         e: Optional[Union[int, float]] = None
         f: float = 2.0
 
-    def test_default(self):
+    def test_default(self) -> None:
         config = parse(self.Config, ["--a", "1"])
         assert config.a == 1
         assert config.b is None
@@ -141,27 +141,27 @@ class TestUnion:
         assert config.d is None
         assert config.e is None
 
-    def test_parse_optional(self):
+    def test_parse_optional(self) -> None:
         config = parse(self.Config, ["--a", "1", "--b", "2"])
         assert config.b == 2
 
-    def test_parse_optional_invalid(self, capsys):
+    def test_parse_optional_invalid(self, capsys) -> None:
         with raises(SystemExit):
             parse(self.Config, ["--a", "1", "--b", "2.0"])
         captured = capsys.readouterr()
         assert "argument --b: invalid typing.Optional[int] value:" in captured.err
 
     @mark.parametrize("value, result", [("1.0", "1.0"), ("11", 11)])
-    def test_parse_union(self, value: str, result: Union[int, str]):
+    def test_parse_union(self, value: str, result: Union[int, str]) -> None:
         config = parse(self.Config, ["--a", "1", "--c", value])  # type: ignore
         assert config.c == result
 
-    def test_parse_inverted_optional(self):
+    def test_parse_inverted_optional(self) -> None:
         config = parse(self.Config, ["--a", "1", "--d", "2"])
         assert config.d == 2
 
     @mark.parametrize("value, result", [("1.0", 1.0), ("11", 11)])
-    def test_parse_optional_union(self, value: str, result: Union[int, str]):
+    def test_parse_optional_union(self, value: str, result: Union[int, str]) -> None:
         config = parse(self.Config, ["--a", "1", "--e", value])  # type: ignore
         assert config.e == result
 
@@ -175,24 +175,24 @@ if version_info >= (3, 10):
             b: int | None = None
             c: int | str = "b"
 
-        def test_default(self):
+        def test_default(self) -> None:
             config = parse(self.Config, ["--a", "1"])
             assert config.a == 1
             assert config.b is None
             assert config.c == "b"
 
-        def test_parse_optional(self):
+        def test_parse_optional(self) -> None:
             config = parse(self.Config, ["--a", "1", "--b", "2"])
             assert config.b == 2
 
-        def test_parse_optional_invalid(self, capsys):
+        def test_parse_optional_invalid(self, capsys) -> None:
             with raises(SystemExit):
                 parse(self.Config, ["--a", "1", "--b", "2.0"])
             captured = capsys.readouterr()
             assert "argument --b: invalid int | None value:" in captured.err
 
         @mark.parametrize("value, result", [("1.0", "1.0"), ("11", 11)])
-        def test_parse_union(self, value: str, result: Union[int, str]):
+        def test_parse_union(self, value: str, result: Union[int, str]) -> None:
             config = parse(self.Config, ["--a", "1", "--c", value])  # type: ignore
             assert config.c == result
 
@@ -207,18 +207,18 @@ class TestBool:
         extra: bool = field(default=False, metadata=dict(as_flags=True, short_option="-x"))
         z: int = 0
 
-    def test_required(self, capsys):
+    def test_required(self, capsys) -> None:
         with raises(SystemExit):
             parse(self.Config, [])
         captured = capsys.readouterr()
         assert "error: the following arguments are required: --a" in captured.err
 
     @mark.parametrize("arg, value", [("0", False), ("1", True), ("true", True), ("false", False)])
-    def test_values(self, arg: str, value: bool):
+    def test_values(self, arg: str, value: bool) -> None:
         config = parse(self.Config, ["--a", arg])  # type: ignore
         assert config.a == value
 
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         config = parse(self.Config, ["--a", "false"])
         assert config.b is False
         assert config.c is True
@@ -226,13 +226,13 @@ class TestBool:
         assert config.extra is False
         assert config.z == 0
 
-    def test_invalid(self, capsys):
+    def test_invalid(self, capsys) -> None:
         with raises(SystemExit):
             parse(self.Config, ["--a", "false", "--b", "invalid"])
         captured = capsys.readouterr()
         assert "error: argument --b: invalid bool value:" in captured.err
 
-    def test_flags(self):
+    def test_flags(self) -> None:
         config = parse(self.Config, ["--a", "false", "--d"])
         assert config.d is True
 
@@ -248,13 +248,13 @@ class TestBool:
         config = parse(self.Config, ["--a", "false", "-x"])
         assert config.extra is True
 
-    def test_flag_argument(self, capsys):
+    def test_flag_argument(self, capsys) -> None:
         with raises(SystemExit):
             parse(self.Config, ["--a", "false", "--e", "invalid"])
         captured = capsys.readouterr()
         assert "error: unrecognized arguments: invalid" in captured.err
 
-    def test_bool_flag_no_default(self, capsys):
+    def test_bool_flag_no_default(self, capsys) -> None:
         @dataclass
         class TConfig:
             a: bool = field(metadata=dict(as_flags=True))
@@ -279,28 +279,28 @@ class TestDate:
             default_factory=datetime.now, metadata=dict(date_format="%m/%d/%Y %H:%M")
         )
 
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         config = parse(self.Config, ["--a-date", "2000-01-01"])
         assert config.another_date == date(2345, 6, 7)
         assert config.a_formatted_date == date(2345, 6, 7)
 
-    def test_required(self, capsys):
+    def test_required(self, capsys) -> None:
         with raises(SystemExit):
             parse(self.Config, [])
         captured = capsys.readouterr()
         assert "error: the following arguments are required: --a-date" in captured.err
 
-    def test_optional(self):
+    def test_optional(self) -> None:
         config = parse(
             self.Config, ["--a-date", "2000-01-01", "--another-date", "2012-12-12", "--a-datetime", "2020-02-03 04:05"]
         )
         assert config.another_date == date(2012, 12, 12)
         assert config.a_datetime == datetime(2020, 2, 3, 4, 5)
 
-    def test_date_format(self):
+    def test_date_format(self) -> None:
         config = parse(self.Config, ["--a-date", "2000-01-01", "--a-formatted-date", "10/20/2000"])
         assert config.a_formatted_date == date(2000, 10, 20)
 
-    def test_datetime_format(self):
+    def test_datetime_format(self) -> None:
         config = parse(self.Config, ["--a-date", "2000-01-01", "--a-formatted-datetime", "8/16/1999 23:45"])
         assert config.a_formatted_datetime == datetime(1999, 8, 16, 23, 45)


### PR DESCRIPTION
Fix the `mypy` error 

```
 error: Value of type variable "Dataclass" of "parse" cannot be "Config"  [type-var]
 ```

For all instances of our tests (and examples)