### PR TITLE
Implement subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,3 +287,6 @@ Note that:
 - Any dataclass can not contain more than one subcommand-field.
 - Sub-commands can be nested and mixed with nested dataclasses.
 - Any positional fields defined after a subcommand-field can not be parsed.
+- Subparsers handle all arguments that come after the command; so all global arguments must come before the command.
+  In the above example this means that  `entrypoint --verbose Command2 string` 
+  is valid but `entrypoint Command2 string --verbose` is not.

--- a/README.md
+++ b/README.md
@@ -293,6 +293,3 @@ Note that:
 - Subparsers handle all arguments that come after the command; so all global arguments must come before the command.
   In the above example this means that  `entrypoint --verbose Command2 string`
   is valid but `entrypoint Command2 string --verbose` is not.
-- Subparsers handle all arguments that come after the command; so all global arguments must come before the command.
-  In the above example this means that  `entrypoint --verbose Command2 string`
-  is valid but `entrypoint Command2 string --verbose` is not.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The dataclass can have fields of the base types: `int`, `float`, `str`, `bool`, 
   that `str | int` will _always_ result in a value of type `str`.
 - Any other type that can be instantiated from a string, such as `Path`.
 - Dataclasses that, in turn, contain fields of supported types. See [Nested Dataclasses](#nested-dataclasses).
+- A union of multiple dataclasses, that in turn contain fields of supported types,
+  which will be parsed in [Subparsers](#subparsers).
 
 ## Metadata
 
@@ -212,7 +214,7 @@ class Base:
 ```
 
 Argument names of fields of the nested dataclass are prefixed with the field name of the nested dataclass in the base
-dataclass. Calling `pydargs.parse(Base, ["-h"])` will result in somthing like:
+dataclass. Calling `pydargs.parse(Base, ["-h"])` will result in something like:
 
 ```text
 usage: your_program.py [-h] --config-field-a CONFIG_FIELD_A
@@ -237,3 +239,51 @@ Please be aware of the following:
   If you must add a default, for example for instantiating your dataclass elsewhere, do `config: Config = field(default_factory=Config)`, assuming that all fields in `Config` have a default.
 - Nested dataclasses can not be positional (although _fields of_ the nested dataclass can be).
 - Argument names must not collide. In the example above, the `Base` class should not contain a field named `config_field_a`.
+
+## Subparsers
+
+Dataclasses can contain a field with a union-of-dataclasses type, e.g.:
+
+```python
+from dataclasses import dataclass, field
+from typing import Union
+
+
+@dataclass
+class Command1:
+  field_a: int
+  field_b: str = "abc"
+
+
+@dataclass
+class Command2:
+  field_c: str = field(metadata=dict(positional=True))
+
+
+@dataclass
+class Base:
+  command: Union[Command1, Command2]
+  verbose: bool = False
+```
+
+This will result in [sub commands](https://docs.python.org/3/library/argparse.html#sub-commands)
+which allow calling your entrypoint as `entrypoint --verbose Command1 --field-a 12`.
+
+Calling `pydargs.parse(Base, ["-h"])` will result in something like:
+
+```text
+usage: your_program.py [-h] [--verbose VERBOSE] {Command1,command1,Command2,command2} ...
+
+options:
+  -h, --help            show this help message and exit
+  --verbose VERBOSE     (default: False)
+
+action:
+  {Command1,command1,Command2,command2}
+```
+
+Note that:
+- Also lower-case command names are accepted.
+- Any dataclass can not contain more than one subcommand-field.
+- Sub-commands can be nested and mixed with nested dataclasses.
+- Any positional fields defined after a subcommand-field can not be parsed.

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -237,13 +237,13 @@ def _add_subparsers(parser, field: Field, prefix: str = "") -> None:
         help=field.metadata.get("help"),
     )
 
-    for arg in get_args(field.type):
+    for command in get_args(field.type):
         subparser = subparsers.add_parser(
-            str(arg.__name__),
+            str(command.__name__),
             argument_default=SUPPRESS,
-            aliases=[str(arg.__name__).lower()],
+            aliases=[str(command.__name__).lower()],
         )
-        _add_arguments(subparser, arg, prefix=f"{prefix}+")
+        _add_arguments(subparser, command, prefix=f"{prefix}+")
 
 
 def _is_command(field: Field) -> bool:

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -1,7 +1,7 @@
 import sys
 from argparse import ArgumentParser, BooleanOptionalAction, Namespace, SUPPRESS
 from collections.abc import Sequence
-from dataclasses import MISSING, dataclass, fields
+from dataclasses import Field, MISSING, dataclass, fields
 from datetime import date, datetime
 from enum import Enum
 from typing import (
@@ -47,7 +47,10 @@ def parse(tp: Type[Dataclass], args: Optional[list[str]] = None, **kwargs: Any) 
         An instance of tp.
     """
     namespace = _create_parser(tp, **kwargs).parse_args(args)
-    return _create_object(tp, namespace)
+    result = _create_object(tp, namespace)
+    if len(namespace.__dict__):
+        raise RuntimeError("Internal pydargs error: Some namespace arguments have not been consumed.")
+    return result
 
 
 def _create_object(tp: Type[Dataclass], namespace: Namespace, prefix: str = "") -> Dataclass:
@@ -59,7 +62,23 @@ def _create_object(tp: Type[Dataclass], namespace: Namespace, prefix: str = "") 
                 prefix + field.name,
                 _create_object(field.type, namespace, prefix=f"{prefix}{field.name}_"),
             )
-    args = {key[len(prefix) :]: value for key, value in namespace.__dict__.items() if key.startswith(prefix)}
+        elif _is_command(field):
+            chosen_action = getattr(namespace, prefix + field.name)
+            # Remove chosen action name and optionally replace with instantiated object.
+            delattr(namespace, prefix + field.name)
+            if chosen_action is not None:
+                for arg in get_args(field.type):
+                    if arg.__name__ == chosen_action:
+                        setattr(namespace, prefix + field.name, _create_object(arg, namespace, prefix=f"{prefix}+"))
+                        break
+                if not hasattr(namespace, prefix + field.name):
+                    raise ValueError("Invalid action.", chosen_action)
+    # Select the relevant keys for the object and remove prefixes.
+    args = {
+        key[len(prefix) :]: value
+        for key, value in namespace.__dict__.items()
+        if key.startswith(prefix) and key[len(prefix) :] in {field.name for field in fields(tp)}
+    }
     # Remove the keys used so far from the namespace, to prevent clutter when creating a parent object.
     for key in args.keys():
         delattr(namespace, prefix + key)
@@ -73,9 +92,16 @@ def _create_parser(tp: Type[Dataclass], **kwargs: Any) -> ArgumentParser:
 
 
 def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = "") -> ArgumentParser:
-    parser_or_group = parser.add_argument_group(prefix.strip("_")) if prefix else parser
+    parser_or_group = (  # Only add a group if there is a prefix that isn't "" or "+".
+        parser.add_argument_group(prefix.strip("_")) if prefix.replace("+", "") else parser
+    )
+    has_subparser = False
     for field in fields(tp):
         if field.metadata.get("ignore_arg", False):
+            continue
+        if _is_command(field):
+            _add_subparsers(parser, field, prefix)
+            has_subparser = True
             continue
 
         argument_kwargs: dict[str, Any] = dict()
@@ -85,14 +111,14 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
             if len(argument_kwargs["help"]):
                 argument_kwargs["help"] += " "
             argument_kwargs["help"] += f"(default: {field.default})"
-        if "metavar" in field.metadata:
-            argument_kwargs["metavar"] = field.metadata["metavar"]
         positional = field.metadata.get("positional", False)
         short_option = field.metadata.get("short_option")
         if positional:
+            if has_subparser:
+                warn("Positional arguments defined after a subparser cannot be parsed.")
             if short_option:
                 raise ValueError("Short options are not supported for positional arguments.")
-            arguments = [prefix + field.name]
+            arguments = [prefix + field.name.replace("+", "")]
             if field_has_default:
                 # Positional arguments that are not required must have a valid default
                 argument_kwargs["default"] = (
@@ -101,12 +127,15 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
                     else field.default
                 )
                 argument_kwargs["nargs"] = "?"
+            # argument_kwargs["dest"] = prefix + field.name
+            argument_kwargs["metavar"] = field.metadata.get("metavar", (prefix + field.name).replace("+", ""))
 
         else:
-            arguments = [f"--{(prefix+field.name).replace('_', '-')}"]
+            arguments = [f"--{(prefix+field.name).replace('_', '-').replace('+', '')}"]
             if short_option:
                 arguments = [short_option] + arguments
             argument_kwargs["dest"] = prefix + field.name
+            argument_kwargs["metavar"] = field.metadata.get("metavar", (prefix + field.name).replace("+", "").upper())
             argument_kwargs["required"] = not field_has_default
 
         if parser_fct := field.metadata.get("parser", None):
@@ -126,6 +155,8 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
             elif origin is Literal:
                 if len({type(arg) for arg in get_args(field.type)}) > 1:
                     raise NotImplementedError("Parsing Literals with mixed types is not supported.")
+                if "metavar" not in field.metadata:
+                    del argument_kwargs["metavar"]  # Remove default metavar in favour of argparse default
                 parser_or_group.add_argument(
                     *arguments,
                     choices=get_args(field.type),
@@ -174,6 +205,8 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
                     **argument_kwargs,
                 )
         elif issubclass(field.type, Enum):
+            if "metavar" not in field.metadata:
+                del argument_kwargs["metavar"]  # Remove default metavar in favour of argparse default
             parser_or_group.add_argument(
                 *arguments,
                 choices=list(field.type),
@@ -194,6 +227,33 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
                 **argument_kwargs,
             )
     return parser
+
+
+def _add_subparsers(parser, field: Field, prefix: str = "") -> None:
+    if not _is_command(field):
+        raise TypeError("An action field must be a Union of dataclasses.")
+
+    subparsers = parser.add_subparsers(
+        dest=prefix + field.name,
+        title=field.name,
+        required=field.default is MISSING and field.default_factory is MISSING,
+        help=field.metadata.get("help"),
+    )
+
+    for arg in get_args(field.type):
+        subparser = subparsers.add_parser(
+            str(arg.__name__),
+            argument_default=SUPPRESS,
+            aliases=[str(arg.__name__).lower()],
+        )
+        _add_arguments(subparser, arg, prefix=f"{prefix}+")
+
+
+def _is_command(field: Field) -> bool:
+    # An action is a Union of dataclass fields.
+    return get_origin(field.type) in UNION_TYPES and all(
+        hasattr(arg, "__dataclass_fields__") for arg in get_args(field.type)
+    )
 
 
 @rename(name="bool")

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -127,7 +127,6 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
                     else field.default
                 )
                 argument_kwargs["nargs"] = "?"
-            # argument_kwargs["dest"] = prefix + field.name
             argument_kwargs["metavar"] = field.metadata.get("metavar", (prefix + field.name).replace("+", ""))
 
         else:

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -64,7 +64,7 @@ def _create_object(tp: Type[Dataclass], namespace: Namespace, prefix: str = "") 
             )
         elif _is_command(field):
             chosen_action = getattr(namespace, prefix + field.name)
-            # Remove chosen action name and optionally replace with instantiated object.
+            # Remove chosen command name and optionally replace with instantiated object.
             delattr(namespace, prefix + field.name)
             if chosen_action is not None:
                 for arg in get_args(field.type):
@@ -72,7 +72,7 @@ def _create_object(tp: Type[Dataclass], namespace: Namespace, prefix: str = "") 
                         setattr(namespace, prefix + field.name, _create_object(arg, namespace, prefix=f"{prefix}+"))
                         break
                 if not hasattr(namespace, prefix + field.name):
-                    raise ValueError("Invalid action.", chosen_action)
+                    raise ValueError("Invalid command.", chosen_action)
     # Select the relevant keys for the object and remove prefixes.
     args = {
         key[len(prefix) :]: value
@@ -246,7 +246,7 @@ def _add_subparsers(parser, field: Field, prefix: str = "") -> None:
 
 
 def _is_command(field: Field) -> bool:
-    # An action is a Union of dataclass fields.
+    # A command is a Union of dataclass fields.
     return get_origin(field.type) in UNION_TYPES and all(
         hasattr(arg, "__dataclass_fields__") for arg in get_args(field.type)
     )

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -230,9 +230,6 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
 
 
 def _add_subparsers(parser, field: Field, prefix: str = "") -> None:
-    if not _is_command(field):
-        raise TypeError("An action field must be a Union of dataclasses.")
-
     subparsers = parser.add_subparsers(
         dest=prefix + field.name,
         title=field.name,

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Union
+from sys import version_info
 
 from pytest import mark, raises
 
@@ -52,6 +53,7 @@ class TestParseAction:
         captured = capsys.readouterr()
         assert help_string in captured.out.replace("\n", "")
 
+    @mark.skipif(version_info < (3, 10), reason="python3.9 prints s slightly different help")
     @mark.parametrize(
         "help_string",
         ["prog Action1 [-h] --a A [--b B]", "options:  -h"],

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -28,7 +28,7 @@ class Command3:
 
 @dataclass
 class Command4:
-    sub_action: Union[Command1, Command2]
+    sub_command: Union[Command1, Command2]
     string4: str = "four"
 
 
@@ -153,8 +153,8 @@ class TestNestedAction:
     def test_args(self, capsys):
         config = parse(self.Config, ["Command4", "Command1", "--a", "-3"])
         assert isinstance(config.mode, Command4)
-        assert isinstance(config.mode.sub_action, Command1)
-        assert config.mode.sub_action.a == -3
+        assert isinstance(config.mode.sub_command, Command1)
+        assert config.mode.sub_command.a == -3
 
 
 class TestCollision:
@@ -209,16 +209,16 @@ class TestPositionalAndSubparser:
 class TestParseActionInNested:
     @dataclass
     class Config:
-        sub: Command4
+        cmd: Command4
         var: int = 12
         flag: bool = field(default=False, metadata=dict(as_flags=True))
 
     @mark.parametrize(
         "help_string",
         [
-            "usage: prog [-h] [--sub-string4 SUB_STRING4] [--var VAR] [--flag | --no-flag]",
+            "usage: prog [-h] [--cmd-string4 CMD_STRING4] [--var VAR] [--flag | --no-flag]",
             "{Command1,command1,Command2,command2} ...",
-            "action:  {Command1,command1,Command2,command2}",
+            "sub_command:  {Command1,command1,Command2,command2}",
         ],
     )
     def test_help(self, capsys, help_string: str):
@@ -231,18 +231,18 @@ class TestParseActionInNested:
         with raises(SystemExit):
             parse(self.Config, ["Command1", "--help"], prog="prog")  # type: ignore
         captured = capsys.readouterr()
-        assert "prog Command1 [-h] --sub-a SUB_A [--sub-b SUB_B]" in captured.out.replace("\n", "")
+        assert "prog Command1 [-h] --cmd-a CMD_A [--cmd-b CMD_B]" in captured.out.replace("\n", "")
 
     def test_is_required(self, capsys):
         with raises(SystemExit):
             parse(self.Config, [])
         captured = capsys.readouterr()
-        assert "the following arguments are required: sub_sub_action" in captured.err
+        assert "the following arguments are required: cmd_sub_command" in captured.err
 
     def test_flag(self, capsys):
         config = parse(self.Config, ["--flag", "Command2"])
-        assert isinstance(config.sub, Command4)
-        assert isinstance(config.sub.sub_action, Command2)
+        assert isinstance(config.cmd, Command4)
+        assert isinstance(config.cmd.sub_command, Command2)
         assert config.flag is True
 
         # Verify that the order matters
@@ -252,12 +252,12 @@ class TestParseActionInNested:
         assert "unrecognized arguments: --flag" in captured.err
 
     def test_action_args(self):
-        config = parse(self.Config, ["Command1", "--sub-a", "12"])
-        assert config.sub.sub_action.a == 12
+        config = parse(self.Config, ["Command1", "--cmd-a", "12"])
+        assert config.cmd.sub_command.a == 12
         assert config.flag is False
 
     def test_parse_positional(self):
-        config = parse(self.Config, ["Command2", "positional", "--sub-c", "12"])
-        assert config.sub.sub_action.c == 12
-        assert config.sub.sub_action.e == "positional"
+        config = parse(self.Config, ["Command2", "positional", "--cmd-c", "12"])
+        assert config.cmd.sub_command.c == 12
+        assert config.cmd.sub_command.e == "positional"
         assert config.flag is False

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -161,7 +161,7 @@ class TestCollision:
     @dataclass
     class Config:
         command: Union[Command1, Command2]
-        a: int = 2
+        a: int = 2  # Command1 also has a field named 'a'
         d: int = 3
 
     def test_help(self, capsys):

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -1,0 +1,263 @@
+from dataclasses import dataclass, field
+from typing import Union
+
+from pytest import mark, raises
+
+from pydargs import parse
+
+
+@dataclass
+class Action1:
+    a: int
+    b: str = "abc"
+
+
+@dataclass
+class Action2:
+    c: int = 42
+    b: str = "abc"
+    e: str = field(default="def", metadata=dict(positional=True))
+
+
+@dataclass
+class Action3:
+    d: float
+    e: list[str] = field(default_factory=lambda: ["def"])
+
+
+@dataclass
+class Action4:
+    sub_action: Union[Action1, Action2]
+    string4: str = "four"
+
+
+class TestParseAction:
+    @dataclass
+    class Config:
+        action: Union[Action1, Action2]
+        var: int = 12
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    @mark.parametrize(
+        "help_string",
+        [
+            "usage: prog [-h] [--var VAR] [--flag | --no-flag]",
+            "{Action1,action1,Action2,action2} ...",
+            "action:  {Action1,action1,Action2,action2}",
+        ],
+    )
+    def test_help(self, capsys, help_string: str):
+        with raises(SystemExit):
+            parse(self.Config, ["--help"], prog="prog")  # type: ignore
+        captured = capsys.readouterr()
+        assert help_string in captured.out.replace("\n", "")
+
+    @mark.parametrize(
+        "help_string",
+        ["prog Action1 [-h] --a A [--b B]", "options:  -h"],
+    )
+    def test_action_help(self, capsys, help_string: str):
+        with raises(SystemExit):
+            parse(self.Config, ["Action1", "--help"], prog="prog")  # type: ignore
+        captured = capsys.readouterr()
+        for line in captured.out.split("\n"):
+            print(line)
+        assert help_string in captured.out.replace("\n", "")
+        assert "prog Action1 [-h] --a A [--b B]" in captured.out.replace("\n", "")
+
+    def test_is_required(self, capsys):
+        with raises(SystemExit):
+            parse(self.Config, [])
+        captured = capsys.readouterr()
+        assert "the following arguments are required: action" in captured.err
+
+    def test_flag(self, capsys):
+        config = parse(self.Config, ["--flag", "Action2"])
+        assert isinstance(config.action, Action2)
+        assert config.action.c == 42
+        assert config.action.b == "abc"
+        assert config.flag is True
+
+        # Verify that the order matters
+        with raises(SystemExit):
+            parse(self.Config, ["Action2", "--flag"])
+        captured = capsys.readouterr()
+        assert "unrecognized arguments: --flag" in captured.err
+
+    def test_action_args(self):
+        config = parse(self.Config, ["Action1", "--a", "12"])
+        assert config.action.a == 12
+        assert config.flag is False
+
+    def test_parse_positional(self):
+        config = parse(self.Config, ["Action2", "positional", "--c", "12"])
+        assert config.action.c == 12
+        assert config.action.e == "positional"
+        assert config.flag is False
+
+
+class TestDoubleAction:
+    @dataclass
+    class Config:
+        action: Union[Action1, Action2]
+        second_action: Union[Action1, Action2, Action3] = field(default_factory=lambda: Action1(a=1))
+        var: int = 12
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    def test_is_not_allowed(self, capsys):
+        with raises(SystemExit):
+            parse(self.Config, [])
+        captured = capsys.readouterr()
+        assert "error: cannot have multiple subparser arguments" in captured.err
+
+
+class TestActionDefault:
+    @dataclass
+    class Config:
+        mode: Union[Action1, Action2, Action3] = field(default_factory=lambda: Action1(0))
+        var: int = 12
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    def test_is_not_required(self, capsys):
+        config = parse(self.Config, [])
+        assert config.mode == Action1(0)
+        assert config.var == 12
+        assert not config.flag
+
+    def test_args(self, capsys):
+        config = parse(self.Config, ["--flag", "Action3", "--d", "0"])
+        assert isinstance(config.mode, Action3)
+        assert config.mode.d == 0
+        assert config.flag is True
+
+        # Verify that the order matters
+        with raises(SystemExit):
+            parse(self.Config, ["Action2", "--flag"])
+        captured = capsys.readouterr()
+        assert "unrecognized arguments: --flag" in captured.err
+
+
+class TestNestedAction:
+    @dataclass
+    class Config:
+        mode: Union[Action1, Action2, Action3, Action4] = field(default_factory=lambda: Action1(0))
+        var: int = 12
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    def test_is_not_required(self, capsys):
+        config = parse(self.Config, [])
+        assert config.mode == Action1(0)
+        assert config.var == 12
+        assert not config.flag
+
+    def test_args(self, capsys):
+        config = parse(self.Config, ["Action4", "Action1", "--a", "-3"])
+        assert isinstance(config.mode, Action4)
+        assert isinstance(config.mode.sub_action, Action1)
+        assert config.mode.sub_action.a == -3
+
+
+class TestCollision:
+    @dataclass
+    class Config:
+        action: Union[Action1, Action2]
+        a: int = 2
+        d: int = 3
+
+    def test_help(self, capsys):
+        with raises(SystemExit):
+            parse(self.Config, ["Action1", "--help"], prog="prog")  # type: ignore
+        captured = capsys.readouterr()
+        assert "prog Action1 [-h] --a A [--b B]" in captured.out.replace("\n", "")
+
+    def test_collision(self, capsys):
+        config = parse(self.Config, ["--a", "4", "--d", "4", "Action1", "--a", "3"])
+        assert config.action.a == 3
+        assert config.d == 4
+        assert config.a == 4
+
+    def test_other_option(self):
+        config = parse(self.Config, ["--a", "4", "--d", "4", "Action2"])
+        assert config.action.c == 42
+        assert config.d == 4
+        assert config.a == 4
+
+
+class TestPositionalAndSubparser:
+    @dataclass
+    class Config:
+        positional_1: str = field(metadata=dict(positional=True))
+        action: Union[Action1, Action2]
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+        positional_2: str = field(default="five", metadata=dict(positional=True))
+
+    def test_warn_positional_after_subparser(self, recwarn):
+        _ = parse(
+            self.Config,
+            ["positional", "Action1", "--a", "12", "--b", "20"],
+        )
+        assert len(recwarn) == 1
+
+    def test_parse_positional(self, recwarn):
+        config = parse(
+            self.Config,
+            ["positional", "Action1", "--a", "12", "--b", "20"],
+        )
+        assert config.positional_1 == "positional"
+
+
+class TestParseActionInNested:
+    @dataclass
+    class Config:
+        sub: Action4
+        var: int = 12
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    @mark.parametrize(
+        "help_string",
+        [
+            "usage: prog [-h] [--sub-string4 SUB_STRING4] [--var VAR] [--flag | --no-flag]",
+            "{Action1,action1,Action2,action2} ...",
+            "action:  {Action1,action1,Action2,action2}",
+        ],
+    )
+    def test_help(self, capsys, help_string: str):
+        with raises(SystemExit):
+            parse(self.Config, ["--help"], prog="prog")  # type: ignore
+        captured = capsys.readouterr()
+        assert help_string in captured.out.replace("\n", "")
+
+    def test_action_help(self, capsys):
+        with raises(SystemExit):
+            parse(self.Config, ["Action1", "--help"], prog="prog")  # type: ignore
+        captured = capsys.readouterr()
+        assert "prog Action1 [-h] --sub-a SUB_A [--sub-b SUB_B]" in captured.out.replace("\n", "")
+
+    def test_is_required(self, capsys):
+        with raises(SystemExit):
+            parse(self.Config, [])
+        captured = capsys.readouterr()
+        assert "the following arguments are required: sub_sub_action" in captured.err
+
+    def test_flag(self, capsys):
+        config = parse(self.Config, ["--flag", "Action2"])
+        assert isinstance(config.sub, Action4)
+        assert isinstance(config.sub.sub_action, Action2)
+        assert config.flag is True
+
+        # Verify that the order matters
+        with raises(SystemExit):
+            parse(self.Config, ["Action2", "--flag"])
+        captured = capsys.readouterr()
+        assert "unrecognized arguments: --flag" in captured.err
+
+    def test_action_args(self):
+        config = parse(self.Config, ["Action1", "--sub-a", "12"])
+        assert config.sub.sub_action.a == 12
+        assert config.flag is False
+
+    def test_parse_positional(self):
+        config = parse(self.Config, ["Action2", "positional", "--sub-c", "12"])
+        assert config.sub.sub_action.c == 12
+        assert config.sub.sub_action.e == "positional"
+        assert config.flag is False

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -8,34 +8,34 @@ from pydargs import parse
 
 
 @dataclass
-class Action1:
+class Command1:
     a: int
     b: str = "abc"
 
 
 @dataclass
-class Action2:
+class Command2:
     c: int = 42
     b: str = "abc"
     e: str = field(default="def", metadata=dict(positional=True))
 
 
 @dataclass
-class Action3:
+class Command3:
     d: float
     e: list[str] = field(default_factory=lambda: ["def"])
 
 
 @dataclass
-class Action4:
-    sub_action: Union[Action1, Action2]
+class Command4:
+    sub_action: Union[Command1, Command2]
     string4: str = "four"
 
 
-class TestParseAction:
+class TestParseCommand:
     @dataclass
     class Config:
-        action: Union[Action1, Action2]
+        command: Union[Command1, Command2]
         var: int = 12
         flag: bool = field(default=False, metadata=dict(as_flags=True))
 
@@ -43,8 +43,8 @@ class TestParseAction:
         "help_string",
         [
             "usage: prog [-h] [--var VAR] [--flag | --no-flag]",
-            "{Action1,action1,Action2,action2} ...",
-            "action:  {Action1,action1,Action2,action2}",
+            "{Command1,command1,Command2,command2} ...",
+            "command:  {Command1,command1,Command2,command2}",
         ],
     )
     def test_help(self, capsys, help_string: str):
@@ -56,51 +56,51 @@ class TestParseAction:
     @mark.skipif(version_info < (3, 10), reason="python3.9 prints a slightly different help message")
     @mark.parametrize(
         "help_string",
-        ["prog Action1 [-h] --a A [--b B]", "options:  -h"],
+        ["prog Command1 [-h] --a A [--b B]", "options:  -h"],
     )
     def test_action_help(self, capsys, help_string: str):
         with raises(SystemExit):
-            parse(self.Config, ["Action1", "--help"], prog="prog")  # type: ignore
+            parse(self.Config, ["Command1", "--help"], prog="prog")  # type: ignore
         captured = capsys.readouterr()
         assert help_string in captured.out.replace("\n", "")
-        assert "prog Action1 [-h] --a A [--b B]" in captured.out.replace("\n", "")
+        assert "prog Command1 [-h] --a A [--b B]" in captured.out.replace("\n", "")
 
     def test_is_required(self, capsys):
         with raises(SystemExit):
             parse(self.Config, [])
         captured = capsys.readouterr()
-        assert "the following arguments are required: action" in captured.err
+        assert "the following arguments are required: command" in captured.err
 
     def test_flag(self, capsys):
-        config = parse(self.Config, ["--flag", "Action2"])
-        assert isinstance(config.action, Action2)
-        assert config.action.c == 42
-        assert config.action.b == "abc"
+        config = parse(self.Config, ["--flag", "Command2"])
+        assert isinstance(config.command, Command2)
+        assert config.command.c == 42
+        assert config.command.b == "abc"
         assert config.flag is True
 
         # Verify that the order matters
         with raises(SystemExit):
-            parse(self.Config, ["Action2", "--flag"])
+            parse(self.Config, ["Command2", "--flag"])
         captured = capsys.readouterr()
         assert "unrecognized arguments: --flag" in captured.err
 
     def test_action_args(self):
-        config = parse(self.Config, ["Action1", "--a", "12"])
-        assert config.action.a == 12
+        config = parse(self.Config, ["Command1", "--a", "12"])
+        assert config.command.a == 12
         assert config.flag is False
 
     def test_parse_positional(self):
-        config = parse(self.Config, ["Action2", "positional", "--c", "12"])
-        assert config.action.c == 12
-        assert config.action.e == "positional"
+        config = parse(self.Config, ["Command2", "positional", "--c", "12"])
+        assert config.command.c == 12
+        assert config.command.e == "positional"
         assert config.flag is False
 
 
 class TestDoubleAction:
     @dataclass
     class Config:
-        action: Union[Action1, Action2]
-        second_action: Union[Action1, Action2, Action3] = field(default_factory=lambda: Action1(a=1))
+        action: Union[Command1, Command2]
+        second_action: Union[Command1, Command2, Command3] = field(default_factory=lambda: Command1(a=1))
         var: int = 12
         flag: bool = field(default=False, metadata=dict(as_flags=True))
 
@@ -114,25 +114,25 @@ class TestDoubleAction:
 class TestActionDefault:
     @dataclass
     class Config:
-        mode: Union[Action1, Action2, Action3] = field(default_factory=lambda: Action1(0))
+        mode: Union[Command1, Command2, Command3] = field(default_factory=lambda: Command1(0))
         var: int = 12
         flag: bool = field(default=False, metadata=dict(as_flags=True))
 
     def test_is_not_required(self, capsys):
         config = parse(self.Config, [])
-        assert config.mode == Action1(0)
+        assert config.mode == Command1(0)
         assert config.var == 12
         assert not config.flag
 
     def test_args(self, capsys):
-        config = parse(self.Config, ["--flag", "Action3", "--d", "0"])
-        assert isinstance(config.mode, Action3)
+        config = parse(self.Config, ["--flag", "Command3", "--d", "0"])
+        assert isinstance(config.mode, Command3)
         assert config.mode.d == 0
         assert config.flag is True
 
         # Verify that the order matters
         with raises(SystemExit):
-            parse(self.Config, ["Action2", "--flag"])
+            parse(self.Config, ["Command2", "--flag"])
         captured = capsys.readouterr()
         assert "unrecognized arguments: --flag" in captured.err
 
@@ -140,45 +140,45 @@ class TestActionDefault:
 class TestNestedAction:
     @dataclass
     class Config:
-        mode: Union[Action1, Action2, Action3, Action4] = field(default_factory=lambda: Action1(0))
+        mode: Union[Command1, Command2, Command3, Command4] = field(default_factory=lambda: Command1(0))
         var: int = 12
         flag: bool = field(default=False, metadata=dict(as_flags=True))
 
     def test_is_not_required(self, capsys):
         config = parse(self.Config, [])
-        assert config.mode == Action1(0)
+        assert config.mode == Command1(0)
         assert config.var == 12
         assert not config.flag
 
     def test_args(self, capsys):
-        config = parse(self.Config, ["Action4", "Action1", "--a", "-3"])
-        assert isinstance(config.mode, Action4)
-        assert isinstance(config.mode.sub_action, Action1)
+        config = parse(self.Config, ["Command4", "Command1", "--a", "-3"])
+        assert isinstance(config.mode, Command4)
+        assert isinstance(config.mode.sub_action, Command1)
         assert config.mode.sub_action.a == -3
 
 
 class TestCollision:
     @dataclass
     class Config:
-        action: Union[Action1, Action2]
+        command: Union[Command1, Command2]
         a: int = 2
         d: int = 3
 
     def test_help(self, capsys):
         with raises(SystemExit):
-            parse(self.Config, ["Action1", "--help"], prog="prog")  # type: ignore
+            parse(self.Config, ["Command1", "--help"], prog="prog")  # type: ignore
         captured = capsys.readouterr()
-        assert "prog Action1 [-h] --a A [--b B]" in captured.out.replace("\n", "")
+        assert "prog Command1 [-h] --a A [--b B]" in captured.out.replace("\n", "")
 
     def test_collision(self, capsys):
-        config = parse(self.Config, ["--a", "4", "--d", "4", "Action1", "--a", "3"])
-        assert config.action.a == 3
+        config = parse(self.Config, ["--a", "4", "--d", "4", "Command1", "--a", "3"])
+        assert config.command.a == 3
         assert config.d == 4
         assert config.a == 4
 
     def test_other_option(self):
-        config = parse(self.Config, ["--a", "4", "--d", "4", "Action2"])
-        assert config.action.c == 42
+        config = parse(self.Config, ["--a", "4", "--d", "4", "Command2"])
+        assert config.command.c == 42
         assert config.d == 4
         assert config.a == 4
 
@@ -187,21 +187,21 @@ class TestPositionalAndSubparser:
     @dataclass
     class Config:
         positional_1: str = field(metadata=dict(positional=True))
-        action: Union[Action1, Action2]
+        action: Union[Command1, Command2]
         flag: bool = field(default=False, metadata=dict(as_flags=True))
         positional_2: str = field(default="five", metadata=dict(positional=True))
 
     def test_warn_positional_after_subparser(self, recwarn):
         _ = parse(
             self.Config,
-            ["positional", "Action1", "--a", "12", "--b", "20"],
+            ["positional", "Command1", "--a", "12", "--b", "20"],
         )
         assert len(recwarn) == 1
 
     def test_parse_positional(self, recwarn):
         config = parse(
             self.Config,
-            ["positional", "Action1", "--a", "12", "--b", "20"],
+            ["positional", "Command1", "--a", "12", "--b", "20"],
         )
         assert config.positional_1 == "positional"
 
@@ -209,7 +209,7 @@ class TestPositionalAndSubparser:
 class TestParseActionInNested:
     @dataclass
     class Config:
-        sub: Action4
+        sub: Command4
         var: int = 12
         flag: bool = field(default=False, metadata=dict(as_flags=True))
 
@@ -217,8 +217,8 @@ class TestParseActionInNested:
         "help_string",
         [
             "usage: prog [-h] [--sub-string4 SUB_STRING4] [--var VAR] [--flag | --no-flag]",
-            "{Action1,action1,Action2,action2} ...",
-            "action:  {Action1,action1,Action2,action2}",
+            "{Command1,command1,Command2,command2} ...",
+            "action:  {Command1,command1,Command2,command2}",
         ],
     )
     def test_help(self, capsys, help_string: str):
@@ -229,9 +229,9 @@ class TestParseActionInNested:
 
     def test_action_help(self, capsys):
         with raises(SystemExit):
-            parse(self.Config, ["Action1", "--help"], prog="prog")  # type: ignore
+            parse(self.Config, ["Command1", "--help"], prog="prog")  # type: ignore
         captured = capsys.readouterr()
-        assert "prog Action1 [-h] --sub-a SUB_A [--sub-b SUB_B]" in captured.out.replace("\n", "")
+        assert "prog Command1 [-h] --sub-a SUB_A [--sub-b SUB_B]" in captured.out.replace("\n", "")
 
     def test_is_required(self, capsys):
         with raises(SystemExit):
@@ -240,24 +240,24 @@ class TestParseActionInNested:
         assert "the following arguments are required: sub_sub_action" in captured.err
 
     def test_flag(self, capsys):
-        config = parse(self.Config, ["--flag", "Action2"])
-        assert isinstance(config.sub, Action4)
-        assert isinstance(config.sub.sub_action, Action2)
+        config = parse(self.Config, ["--flag", "Command2"])
+        assert isinstance(config.sub, Command4)
+        assert isinstance(config.sub.sub_action, Command2)
         assert config.flag is True
 
         # Verify that the order matters
         with raises(SystemExit):
-            parse(self.Config, ["Action2", "--flag"])
+            parse(self.Config, ["Command2", "--flag"])
         captured = capsys.readouterr()
         assert "unrecognized arguments: --flag" in captured.err
 
     def test_action_args(self):
-        config = parse(self.Config, ["Action1", "--sub-a", "12"])
+        config = parse(self.Config, ["Command1", "--sub-a", "12"])
         assert config.sub.sub_action.a == 12
         assert config.flag is False
 
     def test_parse_positional(self):
-        config = parse(self.Config, ["Action2", "positional", "--sub-c", "12"])
+        config = parse(self.Config, ["Command2", "positional", "--sub-c", "12"])
         assert config.sub.sub_action.c == 12
         assert config.sub.sub_action.e == "positional"
         assert config.flag is False

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -62,8 +62,6 @@ class TestParseAction:
         with raises(SystemExit):
             parse(self.Config, ["Action1", "--help"], prog="prog")  # type: ignore
         captured = capsys.readouterr()
-        for line in captured.out.split("\n"):
-            print(line)
         assert help_string in captured.out.replace("\n", "")
         assert "prog Action1 [-h] --a A [--b B]" in captured.out.replace("\n", "")
 

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -53,7 +53,7 @@ class TestParseAction:
         captured = capsys.readouterr()
         assert help_string in captured.out.replace("\n", "")
 
-    @mark.skipif(version_info < (3, 10), reason="python3.9 prints s slightly different help")
+    @mark.skipif(version_info < (3, 10), reason="python3.9 prints a slightly different help message")
     @mark.parametrize(
         "help_string",
         ["prog Action1 [-h] --a A [--b B]", "options:  -h"],


### PR DESCRIPTION
This implements subcommands such as:

```python
from dataclasses import dataclass, field
from typing import Union


@dataclass
class Command1:
  field_a: int
  field_b: str = "abc"


@dataclass
class Command2:
  field_c: str = field(metadata=dict(positional=True))


@dataclass
class Base:
  command: Union[Command1, Command2]
  verbose: bool = False
```
and closes #16 