### PR TITLE
Fix incorrect warnings for subconfigs when no default is provided

### DIFF
--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -143,7 +143,7 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
         elif hasattr(field.type, "__dataclass_fields__"):
             if positional:
                 raise ValueError("Dataclasses may not be positional arguments.")
-            if field.default_factory is not None and field.default_factory != field.type:
+            if field_has_default and field.default_factory != field.type:
                 warn(f"Non-standard default of field {field.name} is ignored by pydargs.", UserWarning)
             # Recursively add arguments for the nested dataclasses
             _add_arguments(parser, field.type, prefix=f"{prefix}{field.name}_")

--- a/tests/test_recursive.py
+++ b/tests/test_recursive.py
@@ -102,8 +102,9 @@ class TestParseRequiredSubConfig:
         sub: SubConfig = field()
         flag: bool = field(default=False, metadata=dict(as_flags=True))
 
-    def test_parse(self):
+    def test_parse(self, recwarn):
         config = parse(self.Config, ["mode"])
+        assert len(recwarn) == 0
         assert config.mode == "mode"
         assert config.sub.a == 42
         assert config.sub.b == "abc"


### PR DESCRIPTION
The `f"Non-standard default of field {field.name} is ignored by pydargs.` warning was issued every time no default was provided for a subconfig, as the default for the default_factory is `MISSING` not `None`.

This includes a test to verify that no warning is issued, and now any `default` provided (instead of `default_factory`) will trigger the same warning. This should be flagged by any linter anyway.