### PR TITLE
Remove argument name prefix after command

### DIFF
--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -245,7 +245,7 @@ def _add_subparsers(parser: ArgumentParser, field: Field, prefix: str, dest_pref
             aliases=[str(command.__name__).lower()],
         )
         # Do not add the field name to the arg prefix -- argument names should not be prefixed with the command name.
-        _add_arguments(subparser, command, arg_prefix=prefix, dest_prefix=f"{dest_prefix}{field.name}_")
+        _add_arguments(subparser, command, arg_prefix="", dest_prefix=f"{dest_prefix}{field.name}_")
 
 
 def _is_command(field: Field) -> bool:

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -231,7 +231,7 @@ class TestParseActionInNested:
         with raises(SystemExit):
             parse(self.Config, ["Command1", "--help"], prog="prog")  # type: ignore
         captured = capsys.readouterr()
-        assert "prog Command1 [-h] --cmd-a CMD_A [--cmd-b CMD_B]" in captured.out.replace("\n", "")
+        assert "prog Command1 [-h] --a A [--b B]" in captured.out.replace("\n", "")
 
     def test_is_required(self, capsys):
         with raises(SystemExit):
@@ -252,12 +252,12 @@ class TestParseActionInNested:
         assert "unrecognized arguments: --flag" in captured.err
 
     def test_action_args(self):
-        config = parse(self.Config, ["Command1", "--cmd-a", "12"])
+        config = parse(self.Config, ["Command1", "--a", "12"])
         assert config.cmd.sub_command.a == 12
         assert config.flag is False
 
     def test_parse_positional(self):
-        config = parse(self.Config, ["Command2", "positional", "--cmd-c", "12"])
+        config = parse(self.Config, ["Command2", "positional", "--c", "12"])
         assert config.cmd.sub_command.c == 12
         assert config.cmd.sub_command.e == "positional"
         assert config.flag is False

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -252,8 +252,8 @@ class TestParseCommandInNested:
         assert "unrecognized arguments: --flag" in captured.err
 
     def test_command_args(self):
-        config = parse(self.Config, ["--a", "12", "Command1", "--a", "12"])
-        assert config.a == 12.0
+        config = parse(self.Config, ["--a", "11", "Command1", "--a", "12"])
+        assert config.a == 11.0
         assert config.cmd.sub_command.a == 12
         assert config.flag is False
 

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -209,13 +209,14 @@ class TestParseCommandInNested:
     @dataclass
     class Config:
         cmd: Command4
+        a: float = 1.0
         var: int = 12
         flag: bool = field(default=False, metadata=dict(as_flags=True))
 
     @mark.parametrize(
         "help_string",
         [
-            "usage: prog [-h] [--cmd-string4 CMD_STRING4] [--var VAR] [--flag | --no-flag]",
+            "usage: prog [-h] [--cmd-string4 CMD_STRING4] [--a A] [--var VAR]",
             "{Command1,command1,Command2,command2} ...",
             "sub_command:  {Command1,command1,Command2,command2}",
         ],
@@ -251,7 +252,8 @@ class TestParseCommandInNested:
         assert "unrecognized arguments: --flag" in captured.err
 
     def test_command_args(self):
-        config = parse(self.Config, ["Command1", "--a", "12"])
+        config = parse(self.Config, ["--a", "12", "Command1", "--a", "12"])
+        assert config.a == 12.0
         assert config.cmd.sub_command.a == 12
         assert config.flag is False
 


### PR DESCRIPTION
This removes the argument name prefix for commands. As all arguments after a command are parsed by the subparser, there is no need for prefixes here.

Note that this is a breaking change - but the example in the README corresponded to the new situation already.