### PR TITLE
Allow overriding defaults from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,49 @@ optional arguments:
   --an-integer INT
 ```
 
+## Loading Defaults from File
+
+Pydargs can also load defaults for the fields in your dataclass from a JSON (or YAML)-formatted file.
+In order to enable this, pass the flag `load_from_file=True` to `parse`.
+This will add a `--file` argument to the parser. Passing a path to a json-formatted file will trigger pydargs to load
+the values from the file as defaults. Any values provided in the file will take precedence over the defaults defined
+in the dataclass, but can be overwritten by their respective command line arguments.
+For example, with the following contents in `defaults.json`:
+
+```json
+{
+  "a": 1,
+  "b": "abc"
+}
+```
+
+then running this code
+
+```python
+from dataclasses import dataclass
+from pydargs import parse
+
+
+@dataclass
+class Config:
+    a: int
+    b: str = "def"
+
+if __name__ == "__main__":
+    config = parse(Config, load_from_file=True)
+```
+
+with the following arguments
+
+`entrypoint --file defaults.json --b xyz`
+
+would result in `Config(a=1, b="xyz")`.
+
+Note that:
+- The defaults provided in the file will not be type-casted by pydargs, and hence only JSON-native types are supported.
+  If required, you can add type-casting by using a pydantic dataclass.
+-
+
 ## Nested Dataclasses
 
 Dataclasses may be nested; the type of a dataclass field may be another dataclass type:

--- a/README.md
+++ b/README.md
@@ -292,7 +292,8 @@ Please be aware of the following:
 - Nested dataclasses can not be positional (although _fields of_ the nested dataclass can be).
 - Argument names must not collide. In the example above, the `Base` class should not contain a field named `config_field_a`.
 - When reading [defaults from a file](#loading-defaults-from-file), the data inside the file may be nested like the dataclasses as well as flat with prefixes.
-  E.g. `{"config": {"field_b": "xyz"}` has the same effect as `{"config_field_b": "xyz"}`. Make sure that there are no collisions between these options.
+  E.g. `{"config": {"field_b": "xyz"}` has the same effect as `{"config_field_b": "xyz"}`. Pydargs will raise an
+  exception in the case of collisions between these alternatives.
 
 ## Subparsers
 

--- a/README.md
+++ b/README.md
@@ -287,3 +287,6 @@ Note that:
 - Any dataclass can not contain more than one subcommand-field.
 - Sub-commands can be nested and mixed with nested dataclasses.
 - Any positional fields defined after a subcommand-field can not be parsed.
+- Subparsers handle all arguments that come after the command; so all global arguments must come before the command.
+  In the above example this means that  `entrypoint --verbose Command2 string` 
+  is valid but `entrypoint Command2 string --verbose` is not.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ if __name__ == "__main__":
 
 with the following arguments
 
-`entrypoint --file defaults.json --b xyz`
+`entrypoint --config-file defaults.json --b xyz`
 
 would result in `Config(a=1, b="xyz")`.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The dataclass can have fields of the base types: `int`, `float`, `str`, `bool`, 
 
 Pydargs can also consume values from a JSON- or YAML-formatted file. To enable
 this, pass `load_from_config=True` to the `parse` function, which will add a `--config-file`
-command line argument. The values from this file will override the defaults
+command line argument. If provided, the values from this file will override the defaults
 of the dataclass fields. Any command line arguments passed will override the
 defaults provided in the file.
 
@@ -117,10 +117,10 @@ would result in `Config(a=1, b="xyz")`.
 
 Note that:
 - Only _defaults_ can be overridden. Any dataclass fields without a default must always be provided on the command line.
-- Any extra keys present inside the file but not matching any field in the dataclass will be ignored,
+- Any extra keys present inside the file but not matching a field in the dataclass will be ignored,
   and if any are present a warning will be raised.
-- In order to load defaults from a YAML-formatted file, PyYAML has to be installed.
-  To install it with pydargs, run `pip install pydargs[pyyaml]`.
+- In order to load defaults from a YAML-formatted file, [PyYAML](https://pyyaml.org/wiki/PyYAMLDocumentation) has
+  to be installed. To install it with pydargs, run `pip install pydargs[pyyaml]`.
 - The parsed dataclass may not have a field named `config_file`.
 - The defaults provided in the file will not be type-casted by pydargs, and hence only JSON-native types are supported.
 
@@ -341,9 +341,6 @@ Note that:
 - Any dataclass can not contain more than one subcommand-field.
 - Sub-commands can be nested and mixed with nested dataclasses.
 - Any positional fields defined after a subcommand-field can not be parsed.
-- Subparsers handle all arguments that come after the command; so all global arguments must come before the command.
-  In the above example this means that  `entrypoint --verbose Command2 string`
-  is valid but `entrypoint Command2 string --verbose` is not.
 - Subparsers handle all arguments that come after the command; so all global arguments must come before the command.
   In the above example this means that  `entrypoint --verbose Command2 string`
   is valid but `entrypoint Command2 string --verbose` is not.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The dataclass can have fields of the base types: `int`, `float`, `str`, `bool`, 
   that `str | int` will _always_ result in a value of type `str`.
 - Any other type that can be instantiated from a string, such as `Path`.
 - Dataclasses that, in turn, contain fields of supported types. See [Nested Dataclasses](#nested-dataclasses).
+- A union of multiple dataclasses, that in turn contain fields of supported types,
+  which will be parsed in [Subparsers](#subparsers).
 
 ## Metadata
 
@@ -212,7 +214,7 @@ class Base:
 ```
 
 Argument names of fields of the nested dataclass are prefixed with the field name of the nested dataclass in the base
-dataclass. Calling `pydargs.parse(Base, ["-h"])` will result in somthing like:
+dataclass. Calling `pydargs.parse(Base, ["-h"])` will result in something like:
 
 ```text
 usage: your_program.py [-h] --config-field-a CONFIG_FIELD_A
@@ -237,3 +239,51 @@ Please be aware of the following:
   If you must add a default, for example for instantiating your dataclass elsewhere, do `config: Config = field(default_factory=Config)`, assuming that all fields in `Config` have a default.
 - Nested dataclasses can not be positional (although _fields of_ the nested dataclass can be).
 - Argument names must not collide. In the example above, the `Base` class should not contain a field named `config_field_a`.
+
+## Subparsers
+
+Dataclasses can contain a field with a union-of-dataclasses type, e.g.:
+
+```python
+from dataclasses import dataclass, field
+from typing import Union
+
+
+@dataclass
+class Command1:
+  field_a: int
+  field_b: str = "abc"
+
+
+@dataclass
+class Command2:
+  field_c: str = field(metadata=dict(positional=True))
+
+
+@dataclass
+class Base:
+  command: Union[Command1, Command2]
+  verbose: bool = False
+```
+
+This will result in [sub commands](https://docs.python.org/3/library/argparse.html#sub-commands)
+which allow calling your entrypoint as `entrypoint --verbose Command1 --field-a 12`.
+
+Calling `pydargs.parse(Base, ["-h"])` will result in something like:
+
+```text
+usage: your_program.py [-h] [--verbose VERBOSE] {Command1,command1,Command2,command2} ...
+
+options:
+  -h, --help            show this help message and exit
+  --verbose VERBOSE     (default: False)
+
+action:
+  {Command1,command1,Command2,command2}
+```
+
+Note that:
+- Also lower-case command names are accepted.
+- Any dataclass can not contain more than one subcommand-field.
+- Sub-commands can be nested and mixed with nested dataclasses.
+- Any positional fields defined after a subcommand-field can not be parsed.

--- a/README.md
+++ b/README.md
@@ -78,10 +78,42 @@ The dataclass can have fields of the base types: `int`, `float`, `str`, `bool`, 
 ## Overriding defaults from a file
 
 Pydargs can also consume values from a JSON- or YAML-formatted file. To enable
-this, pass `load_from_file=True` to the `parse` function, which will add a `--file`
+this, pass `load_from_config=True` to the `parse` function, which will add a `--config-file`
 command line argument. The values from this file will override the defaults
 of the dataclass fields. Any command line arguments passed will override the
 defaults provided in the file.
+
+For example, with the following contents in `defaults.json`:
+
+```json
+{
+  "a": 1,
+  "b": "abc"
+}
+```
+
+then running this code
+
+```python
+from dataclasses import dataclass
+from pydargs import parse
+
+
+@dataclass
+class Config:
+  a: int = 2
+  b: str = "def"
+
+
+if __name__ == "__main__":
+  config = parse(Config, load_from_config=True)
+```
+
+with the following arguments
+
+`entrypoint --file defaults.json --b xyz`
+
+would result in `Config(a=1, b="xyz")`.
 
 Note that:
 - Only _defaults_ can be overridden. Any dataclass fields without a default must always be provided on the command line.
@@ -89,7 +121,8 @@ Note that:
   and if any are present a warning will be raised.
 - In order to load defaults from a YAML-formatted file, PyYAML has to be installed.
   To install it with pydargs, run `pip install pydargs[pyyaml]`.
-- The parsed dataclass may not have a field named `file`.
+- The parsed dataclass may not have a field named `config_file`.
+- The defaults provided in the file will not be type-casted by pydargs, and hence only JSON-native types are supported.
 
 ## Metadata
 
@@ -212,49 +245,6 @@ optional arguments:
   -h, --help        show this help message and exit
   --an-integer INT
 ```
-
-## Loading Defaults from File
-
-Pydargs can also load defaults for the fields in your dataclass from a JSON (or YAML)-formatted file.
-In order to enable this, pass the flag `load_from_file=True` to `parse`.
-This will add a `--file` argument to the parser. Passing a path to a json-formatted file will trigger pydargs to load
-the values from the file as defaults. Any values provided in the file will take precedence over the defaults defined
-in the dataclass, but can be overwritten by their respective command line arguments.
-For example, with the following contents in `defaults.json`:
-
-```json
-{
-  "a": 1,
-  "b": "abc"
-}
-```
-
-then running this code
-
-```python
-from dataclasses import dataclass
-from pydargs import parse
-
-
-@dataclass
-class Config:
-    a: int
-    b: str = "def"
-
-if __name__ == "__main__":
-    config = parse(Config, load_from_file=True)
-```
-
-with the following arguments
-
-`entrypoint --file defaults.json --b xyz`
-
-would result in `Config(a=1, b="xyz")`.
-
-Note that:
-- The defaults provided in the file will not be type-casted by pydargs, and hence only JSON-native types are supported.
-  If required, you can add type-casting by using a pydantic dataclass.
--
 
 ## Nested Dataclasses
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Please be aware of the following:
 - Argument names must not collide. In the example above, the `Base` class should not contain a field named `config_field_a`.
 - When reading [defaults from a file](#loading-defaults-from-file), the data inside the file may be nested like the dataclasses as well as flat with prefixes.
   E.g. `{"config": {"field_b": "xyz"}` has the same effect as `{"config_field_b": "xyz"}`. Pydargs will raise an
-  exception in the case of collisions between these alternatives.
+  exception in the case of collisions between keys in alternative formats.
 
 ## Subparsers
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,22 @@ The dataclass can have fields of the base types: `int`, `float`, `str`, `bool`, 
 - A union of multiple dataclasses, that in turn contain fields of supported types,
   which will be parsed in [Subparsers](#subparsers).
 
+## Overriding defaults from a file
+
+Pydargs can also consume values from a JSON- or YAML-formatted file. To enable
+this, pass `load_from_file=True` to the `parse` function, which will add a `--file`
+command line argument. The values from this file will override the defaults
+of the dataclass fields. Any command line arguments passed will override the
+defaults provided in the file.
+
+Note that:
+- Only _defaults_ can be overridden. Any dataclass fields without a default must always be provided on the command line.
+- Any extra keys present inside the file but not matching any field in the dataclass will be ignored,
+  and if any are present a warning will be raised.
+- In order to load defaults from a YAML-formatted file, PyYAML has to be installed.
+  To install it with pydargs, run `pip install pydargs[pyyaml]`.
+- The parsed dataclass may not have a field named `file`.
+
 ## Metadata
 
 Additional options can be provided to the dataclass field metadata.
@@ -285,6 +301,8 @@ Please be aware of the following:
   If you must add a default, for example for instantiating your dataclass elsewhere, do `config: Config = field(default_factory=Config)`, assuming that all fields in `Config` have a default.
 - Nested dataclasses can not be positional (although _fields of_ the nested dataclass can be).
 - Argument names must not collide. In the example above, the `Base` class should not contain a field named `config_field_a`.
+- When reading [defaults from a file](#loading-defaults-from-file), the data inside the file may be nested like the dataclasses as well as flat with prefixes.
+  E.g. `{"config": {"field_b": "xyz"}` has the same as `{"config_field_b": "xyz"}`. Make sure that there are no collisions between these options.
 
 ## Subparsers
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The dataclass can have fields of the base types: `int`, `float`, `str`, `bool`, 
 ## Overriding defaults from a file
 
 Pydargs can also consume values from a JSON- or YAML-formatted file. To enable
-this, pass `load_from_config=True` to the `parse` function, which will add a `--config-file`
+this, pass `add_config_file_argument=True` to the `parse` function, which will add a `--config-file`
 command line argument. If provided, the values from this file will override the defaults
 of the dataclass fields. Any command line arguments passed will override the
 defaults provided in the file.
@@ -157,7 +157,7 @@ class Config:
 
 
 if __name__ == "__main__":
-  config = parse(Config, load_from_config=True)
+  config = parse(Config, add_config_file_argument=True)
 ```
 
 with the following arguments

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Please be aware of the following:
 - Nested dataclasses can not be positional (although _fields of_ the nested dataclass can be).
 - Argument names must not collide. In the example above, the `Base` class should not contain a field named `config_field_a`.
 - When reading [defaults from a file](#loading-defaults-from-file), the data inside the file may be nested like the dataclasses as well as flat with prefixes.
-  E.g. `{"config": {"field_b": "xyz"}` has the same as `{"config_field_b": "xyz"}`. Make sure that there are no collisions between these options.
+  E.g. `{"config": {"field_b": "xyz"}` has the same effect as `{"config_field_b": "xyz"}`. Make sure that there are no collisions between these options.
 
 ## Subparsers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,9 @@ dependencies = []
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dev = ["mypy==1.6.1", "pre-commit==3.5.0", "ruff==0.1.5", "pytest==7.4.3"]
+dev = ["mypy==1.6.1", "pre-commit==3.5.0", "ruff==0.1.5", "pytest==7.4.3", "pydargs[yaml]"]
 pydantic = ["pydantic>=2.0"]
+yaml = ["pyyaml"]
 
 [project.urls]
 Repository = "https://github.com/rogiervandergeer/pydargs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = ["mypy==1.6.1", "pre-commit==3.5.0", "ruff==0.1.5", "pytest==7.4.3", "pydargs[yaml]"]
 pydantic = ["pydantic>=2.0"]
-yaml = ["pyyaml"]
+yaml = ["pyyaml>=5.0"]
 
 [project.urls]
 Repository = "https://github.com/rogiervandergeer/pydargs"

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -165,7 +165,7 @@ def _create_parser(tp: Type[Dataclass], load_from_config: bool, **kwargs: Any) -
             "--config-file",
             required=False,
             type=Path,
-            help=f"Override configuration defaults from a {supported_types}-formatted file.",
+            help=f"Override configuration defaults from a {supported_types}formatted file.",
         )
     _add_arguments(parser, tp)
     return parser

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -237,13 +237,13 @@ def _add_subparsers(parser, field: Field, prefix: str = "") -> None:
         help=field.metadata.get("help"),
     )
 
-    for arg in get_args(field.type):
+    for command in get_args(field.type):
         subparser = subparsers.add_parser(
-            str(arg.__name__),
+            str(command.__name__),
             argument_default=SUPPRESS,
-            aliases=[str(arg.__name__).lower()],
+            aliases=[str(command.__name__).lower()],
         )
-        _add_arguments(subparser, arg, prefix=f"{prefix}+")
+        _add_arguments(subparser, command, prefix=f"{prefix}+")
 
 
 def _is_command(field: Field) -> bool:

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -43,7 +43,7 @@ def parse(
     Args:
         tp: Type of the object to instantiate. This is expected to be a dataclass.
         args: Optional list of arguments. Defaults to sys.argv.
-        load_from_config: If True, add a --config-file argument to load defaults from a JSON or YAML file.
+        load_from_config: If True, add a --config-file argument to load defaults from a JSON- or YAML-formatted file.
         **kwargs: Keyword arguments passed to the ArgumentParser object.
 
     Returns:

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -1,7 +1,7 @@
 import sys
 from argparse import ArgumentParser, BooleanOptionalAction, Namespace, SUPPRESS
 from collections.abc import Sequence
-from dataclasses import MISSING, dataclass, fields
+from dataclasses import Field, MISSING, dataclass, fields
 from datetime import date, datetime
 from enum import Enum
 from typing import (
@@ -47,7 +47,10 @@ def parse(tp: Type[Dataclass], args: Optional[list[str]] = None, **kwargs: Any) 
         An instance of tp.
     """
     namespace = _create_parser(tp, **kwargs).parse_args(args)
-    return _create_object(tp, namespace)
+    result = _create_object(tp, namespace)
+    if len(namespace.__dict__):
+        raise RuntimeError("Internal pydargs error: Some namespace arguments have not been consumed.")
+    return result
 
 
 def _create_object(tp: Type[Dataclass], namespace: Namespace, prefix: str = "") -> Dataclass:
@@ -59,7 +62,23 @@ def _create_object(tp: Type[Dataclass], namespace: Namespace, prefix: str = "") 
                 prefix + field.name,
                 _create_object(field.type, namespace, prefix=f"{prefix}{field.name}_"),
             )
-    args = {key[len(prefix) :]: value for key, value in namespace.__dict__.items() if key.startswith(prefix)}
+        elif _is_command(field):
+            chosen_action = getattr(namespace, prefix + field.name)
+            # Remove chosen action name and optionally replace with instantiated object.
+            delattr(namespace, prefix + field.name)
+            if chosen_action is not None:
+                for arg in get_args(field.type):
+                    if arg.__name__ == chosen_action:
+                        setattr(namespace, prefix + field.name, _create_object(arg, namespace, prefix=f"{prefix}+"))
+                        break
+                if not hasattr(namespace, prefix + field.name):
+                    raise ValueError("Invalid action.", chosen_action)
+    # Select the relevant keys for the object and remove prefixes.
+    args = {
+        key[len(prefix) :]: value
+        for key, value in namespace.__dict__.items()
+        if key.startswith(prefix) and key[len(prefix) :] in {field.name for field in fields(tp)}
+    }
     # Remove the keys used so far from the namespace, to prevent clutter when creating a parent object.
     for key in args.keys():
         delattr(namespace, prefix + key)
@@ -73,9 +92,16 @@ def _create_parser(tp: Type[Dataclass], **kwargs: Any) -> ArgumentParser:
 
 
 def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = "") -> ArgumentParser:
-    parser_or_group = parser.add_argument_group(prefix.strip("_")) if prefix else parser
+    parser_or_group = (  # Only add a group if there is a prefix that isn't "" or "+".
+        parser.add_argument_group(prefix.strip("_")) if prefix.replace("+", "") else parser
+    )
+    has_subparser = False
     for field in fields(tp):
         if field.metadata.get("ignore_arg", False):
+            continue
+        if _is_command(field):
+            _add_subparsers(parser, field, prefix)
+            has_subparser = True
             continue
 
         argument_kwargs: dict[str, Any] = dict()
@@ -85,14 +111,14 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
             if len(argument_kwargs["help"]):
                 argument_kwargs["help"] += " "
             argument_kwargs["help"] += f"(default: {field.default})"
-        if "metavar" in field.metadata:
-            argument_kwargs["metavar"] = field.metadata["metavar"]
         positional = field.metadata.get("positional", False)
         short_option = field.metadata.get("short_option")
         if positional:
+            if has_subparser:
+                warn("Positional arguments defined after a subparser cannot be parsed.")
             if short_option:
                 raise ValueError("Short options are not supported for positional arguments.")
-            arguments = [prefix + field.name]
+            arguments = [prefix + field.name.replace("+", "")]
             if field_has_default:
                 # Positional arguments that are not required must have a valid default
                 argument_kwargs["default"] = (
@@ -101,12 +127,15 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
                     else field.default
                 )
                 argument_kwargs["nargs"] = "?"
+            # argument_kwargs["dest"] = prefix + field.name
+            argument_kwargs["metavar"] = field.metadata.get("metavar", (prefix + field.name).replace("+", ""))
 
         else:
-            arguments = [f"--{(prefix+field.name).replace('_', '-')}"]
+            arguments = [f"--{(prefix+field.name).replace('_', '-').replace('+', '')}"]
             if short_option:
                 arguments = [short_option] + arguments
             argument_kwargs["dest"] = prefix + field.name
+            argument_kwargs["metavar"] = field.metadata.get("metavar", (prefix + field.name).replace("+", "").upper())
             argument_kwargs["required"] = not field_has_default
 
         if parser_fct := field.metadata.get("parser", None):
@@ -126,6 +155,8 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
             elif origin is Literal:
                 if len({type(arg) for arg in get_args(field.type)}) > 1:
                     raise NotImplementedError("Parsing Literals with mixed types is not supported.")
+                if "metavar" not in field.metadata:
+                    del argument_kwargs["metavar"]  # Remove default metavar in favour of argparse default
                 parser_or_group.add_argument(
                     *arguments,
                     choices=get_args(field.type),
@@ -174,6 +205,8 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
                     **argument_kwargs,
                 )
         elif issubclass(field.type, Enum):
+            if "metavar" not in field.metadata:
+                del argument_kwargs["metavar"]  # Remove default metavar in favour of argparse default
             parser_or_group.add_argument(
                 *arguments,
                 choices=list(field.type),
@@ -194,6 +227,33 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
                 **argument_kwargs,
             )
     return parser
+
+
+def _add_subparsers(parser, field: Field, prefix: str = "") -> None:
+    if not _is_command(field):
+        raise TypeError("An action field must be a Union of dataclasses.")
+
+    subparsers = parser.add_subparsers(
+        dest=prefix + field.name,
+        title=field.name,
+        required=field.default is MISSING and field.default_factory is MISSING,
+        help=field.metadata.get("help"),
+    )
+
+    for arg in get_args(field.type):
+        subparser = subparsers.add_parser(
+            str(arg.__name__),
+            argument_default=SUPPRESS,
+            aliases=[str(arg.__name__).lower()],
+        )
+        _add_arguments(subparser, arg, prefix=f"{prefix}+")
+
+
+def _is_command(field: Field) -> bool:
+    # An action is a Union of dataclass fields.
+    return get_origin(field.type) in UNION_TYPES and all(
+        hasattr(arg, "__dataclass_fields__") for arg in get_args(field.type)
+    )
 
 
 @rename(name="bool")

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -36,25 +36,26 @@ Dataclass = TypeVar("Dataclass", bound=DataClassProtocol)
 
 
 def parse(
-    tp: Type[Dataclass], args: Optional[list[str]] = None, load_from_config: bool = False, **kwargs: Any
+    tp: Type[Dataclass], args: Optional[list[str]] = None, add_config_file_argument: bool = False, **kwargs: Any
 ) -> Dataclass:
     """Instantiate an object of the provided dataclass type from command line arguments.
 
     Args:
         tp: Type of the object to instantiate. This is expected to be a dataclass.
         args: Optional list of arguments. Defaults to sys.argv.
-        load_from_config: If True, add a --config-file argument to load defaults from a JSON- or YAML-formatted file.
+        add_config_file_argument: If True, add a --config-file argument to load allow loading
+            defaults from a JSON- or YAML-formatted file.
         **kwargs: Keyword arguments passed to the ArgumentParser object.
 
     Returns:
         An instance of tp.
     """
-    namespace = _create_parser(tp, load_from_config=load_from_config, **kwargs).parse_args(args)
-    if load_from_config:
+    namespace = _create_parser(tp, add_config_file_argument=add_config_file_argument, **kwargs).parse_args(args)
+    if add_config_file_argument:
         _add_defaults_from_file(namespace)
     result = _create_object(tp, namespace)
     if len(namespace.__dict__):
-        if load_from_config:
+        if add_config_file_argument:
             warn(
                 "The following keys from the provided configuration file were "
                 f"not consumed: {', '.join(namespace.__dict__.keys())}"
@@ -157,9 +158,9 @@ def _create_object(tp: Type[Dataclass], namespace: Namespace, prefix: str = "") 
     return tp(**args)
 
 
-def _create_parser(tp: Type[Dataclass], load_from_config: bool, **kwargs: Any) -> ArgumentParser:
+def _create_parser(tp: Type[Dataclass], add_config_file_argument: bool, **kwargs: Any) -> ArgumentParser:
     parser = ArgumentParser(**kwargs, argument_default=SUPPRESS)
-    if load_from_config:
+    if add_config_file_argument:
         supported_types = "JSON- or YAML-" if yaml_available() else "JSON-"
         parser.add_argument(
             "--config-file",

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -127,7 +127,6 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
                     else field.default
                 )
                 argument_kwargs["nargs"] = "?"
-            # argument_kwargs["dest"] = prefix + field.name
             argument_kwargs["metavar"] = field.metadata.get("metavar", (prefix + field.name).replace("+", ""))
 
         else:

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -230,9 +230,6 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
 
 
 def _add_subparsers(parser, field: Field, prefix: str = "") -> None:
-    if not _is_command(field):
-        raise TypeError("An action field must be a Union of dataclasses.")
-
     subparsers = parser.add_subparsers(
         dest=prefix + field.name,
         title=field.name,

--- a/src/pydargs/__init__.py
+++ b/src/pydargs/__init__.py
@@ -69,7 +69,11 @@ def _create_object(tp: Type[Dataclass], namespace: Namespace, prefix: str = "") 
             if chosen_action is not None:
                 for arg in get_args(field.type):
                     if arg.__name__ == chosen_action:
-                        setattr(namespace, prefix + field.name, _create_object(arg, namespace, prefix=f"{prefix}+"))
+                        setattr(
+                            namespace,
+                            prefix + field.name,
+                            _create_object(arg, namespace, prefix=f"{prefix}{field.name}_"),
+                        )
                         break
                 if not hasattr(namespace, prefix + field.name):
                     raise ValueError("Invalid command.", chosen_action)
@@ -91,16 +95,18 @@ def _create_parser(tp: Type[Dataclass], **kwargs: Any) -> ArgumentParser:
     return parser
 
 
-def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = "") -> ArgumentParser:
-    parser_or_group = (  # Only add a group if there is a prefix that isn't "" or "+".
-        parser.add_argument_group(prefix.strip("_")) if prefix.replace("+", "") else parser
+def _add_arguments(
+    parser: ArgumentParser, tp: Type[Dataclass], arg_prefix: str = "", dest_prefix: str = ""
+) -> ArgumentParser:
+    parser_or_group = (  # Only add a group if there is a arg_prefix that isn't "".
+        parser.add_argument_group(arg_prefix.strip("_")) if arg_prefix else parser
     )
     has_subparser = False
     for field in fields(tp):
         if field.metadata.get("ignore_arg", False):
             continue
         if _is_command(field):
-            _add_subparsers(parser, field, prefix)
+            _add_subparsers(parser, field, arg_prefix, dest_prefix)
             has_subparser = True
             continue
 
@@ -118,7 +124,7 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
                 warn("Positional arguments defined after a subparser cannot be parsed.")
             if short_option:
                 raise ValueError("Short options are not supported for positional arguments.")
-            arguments = [prefix + field.name.replace("+", "")]
+            arguments = [dest_prefix + field.name]
             if field_has_default:
                 # Positional arguments that are not required must have a valid default
                 argument_kwargs["default"] = (
@@ -127,14 +133,14 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
                     else field.default
                 )
                 argument_kwargs["nargs"] = "?"
-            argument_kwargs["metavar"] = field.metadata.get("metavar", (prefix + field.name).replace("+", ""))
+            argument_kwargs["metavar"] = field.metadata.get("metavar", (arg_prefix + field.name))
 
         else:
-            arguments = [f"--{(prefix+field.name).replace('_', '-').replace('+', '')}"]
+            arguments = [f"--{(arg_prefix + field.name).replace('_', '-')}"]
             if short_option:
                 arguments = [short_option] + arguments
-            argument_kwargs["dest"] = prefix + field.name
-            argument_kwargs["metavar"] = field.metadata.get("metavar", (prefix + field.name).replace("+", "").upper())
+            argument_kwargs["dest"] = dest_prefix + field.name
+            argument_kwargs["metavar"] = field.metadata.get("metavar", (arg_prefix + field.name).upper())
             argument_kwargs["required"] = not field_has_default
 
         if parser_fct := field.metadata.get("parser", None):
@@ -176,7 +182,7 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
             if field_has_default and field.default_factory != field.type:
                 warn(f"Non-standard default of field {field.name} is ignored by pydargs.", UserWarning)
             # Recursively add arguments for the nested dataclasses
-            _add_arguments(parser, field.type, prefix=f"{prefix}{field.name}_")
+            _add_arguments(parser, field.type, f"{arg_prefix}{field.name}_", f"{dest_prefix}{field.name}_")
         elif field.type in (date, datetime):
             parser_or_group.add_argument(
                 *arguments,
@@ -192,11 +198,7 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
             if field.metadata.get("as_flags", False):
                 if positional:
                     raise ValueError("A field cannot be positional as well as be represented by flags.")
-                parser_or_group.add_argument(
-                    *arguments,
-                    action=BooleanOptionalAction,
-                    **argument_kwargs,
-                )
+                parser_or_group.add_argument(*arguments, action=BooleanOptionalAction, **argument_kwargs)
             else:
                 parser_or_group.add_argument(
                     *arguments,
@@ -228,9 +230,9 @@ def _add_arguments(parser: ArgumentParser, tp: Type[Dataclass], prefix: str = ""
     return parser
 
 
-def _add_subparsers(parser, field: Field, prefix: str = "") -> None:
+def _add_subparsers(parser: ArgumentParser, field: Field, prefix: str, dest_prefix: str) -> None:
     subparsers = parser.add_subparsers(
-        dest=prefix + field.name,
+        dest=dest_prefix + field.name,
         title=field.name,
         required=field.default is MISSING and field.default_factory is MISSING,
         help=field.metadata.get("help"),
@@ -242,7 +244,8 @@ def _add_subparsers(parser, field: Field, prefix: str = "") -> None:
             argument_default=SUPPRESS,
             aliases=[str(command.__name__).lower()],
         )
-        _add_arguments(subparser, command, prefix=f"{prefix}+")
+        # Do not add the field name to the arg prefix -- argument names should not be prefixed with the command name.
+        _add_arguments(subparser, command, arg_prefix=prefix, dest_prefix=f"{dest_prefix}{field.name}_")
 
 
 def _is_command(field: Field) -> bool:

--- a/src/pydargs/utils.py
+++ b/src/pydargs/utils.py
@@ -1,4 +1,5 @@
-from functools import partial
+from functools import cache, partial
+from importlib.util import find_spec
 from typing import Any, Callable, TypeVar
 
 Fct = TypeVar("Fct")
@@ -18,3 +19,8 @@ def rename(name: str) -> Callable[[Fct], Fct]:
         return f
 
     return wrapper
+
+
+@cache
+def yaml_available() -> bool:
+    return find_spec("yaml") is not None

--- a/tests/test_from_file.py
+++ b/tests/test_from_file.py
@@ -2,6 +2,8 @@ from argparse import ArgumentError
 from dataclasses import dataclass, field
 from json import dumps
 from pathlib import Path
+from typing import Optional
+
 from yaml import dump
 
 from pytest import raises, warns
@@ -110,7 +112,7 @@ class TestFileCollision:
     @dataclass
     class Config:
         a: int = 5
-        file: Path | None = None
+        file: Optional[Path] = None
 
     def test_parse_no_file(self) -> None:
         config = parse(self.Config, [], load_from_file=False)

--- a/tests/test_from_file.py
+++ b/tests/test_from_file.py
@@ -33,7 +33,7 @@ class TestParseFromFile:
         z: str = "dummy"
 
     def test_parse_no_file(self) -> None:
-        config = parse(self.Config, [], load_from_file=True)
+        config = parse(self.Config, [], load_from_config=True)
         assert config.a == 5
         assert config.b == "something"
         assert config.c is False
@@ -41,7 +41,7 @@ class TestParseFromFile:
 
     def test_parse_with_file(self, tmp_path: Path) -> None:
         (tmp_path / "config.json").write_text(dumps({"a": 6}))
-        config = parse(self.Config, ["--file", str((tmp_path / "config.json"))], load_from_file=True)
+        config = parse(self.Config, ["--config-file", str((tmp_path / "config.json"))], load_from_config=True)
         assert config.a == 6
         assert config.b == "something"
         assert config.c is False
@@ -49,7 +49,9 @@ class TestParseFromFile:
 
     def test_parse_with_file_override(self, tmp_path: Path) -> None:
         (tmp_path / "config.json").write_text(dumps({"a": 6}))
-        config = parse(self.Config, ["--file", str((tmp_path / "config.json")), "--a", "7"], load_from_file=True)
+        config = parse(
+            self.Config, ["--config-file", str((tmp_path / "config.json")), "--a", "7"], load_from_config=True
+        )
         assert config.a == 7
         assert config.b == "something"
         assert config.c is False
@@ -57,7 +59,9 @@ class TestParseFromFile:
 
     def test_nested_with_file_and_override(self, tmp_path: Path) -> None:
         (tmp_path / "config.yaml").write_text(dump({"a": 6, "s": {"a": 1, "b": "c", "s": {"q": "z"}}}))
-        config = parse(self.Config, ["--file", str((tmp_path / "config.yaml")), "--s-b", "d"], load_from_file=True)
+        config = parse(
+            self.Config, ["--config-file", str((tmp_path / "config.yaml")), "--s-b", "d"], load_from_config=True
+        )
         assert config.a == 6
         assert config.b == "something"
         assert config.c is False
@@ -68,7 +72,7 @@ class TestParseFromFile:
 
     def test_nested_with_prefixed_keys(self, tmp_path: Path) -> None:
         (tmp_path / "config.yaml").write_text(dump({"a": 6, "s_a": 1, "s": {"b": "c"}}))
-        config = parse(self.Config, ["--file", str((tmp_path / "config.yaml"))], load_from_file=True)
+        config = parse(self.Config, ["--config-file", str((tmp_path / "config.yaml"))], load_from_config=True)
         assert config.a == 6
         assert config.s.a == 1
         assert config.s.b == "c"
@@ -76,17 +80,17 @@ class TestParseFromFile:
     def test_nested_with_duplicate_keys(self, tmp_path: Path) -> None:
         (tmp_path / "config.yaml").write_text(dump({"a": 6, "s_a": 1, "s": {"a": 2, "b": "c"}}))
         with raises(KeyError) as e:
-            parse(self.Config, ["--file", str((tmp_path / "config.yaml"))], load_from_file=True)
-        assert str(e.value) == "'Collision between keys in defaults file on key s_a.'"
+            parse(self.Config, ["--config-file", str((tmp_path / "config.yaml"))], load_from_config=True)
+        assert str(e.value) == "'Collision between keys in config file on key s_a.'"
 
     def test_parse_with_nonexistent_file(self, tmp_path: Path) -> None:
         with raises(FileNotFoundError):
-            parse(self.Config, ["--file", str((tmp_path / "config.json"))], load_from_file=True)
+            parse(self.Config, ["--config-file", str((tmp_path / "config.json"))], load_from_config=True)
 
     def test_parse_with_extra_fields(self, tmp_path: Path) -> None:
         (tmp_path / "config.json").write_text(dumps({"a": 6, "d": "this_is_extra"}))
         with warns(UserWarning) as warnings:
-            parse(self.Config, ["--file", str((tmp_path / "config.json"))], load_from_file=True)
+            parse(self.Config, ["--config-file", str((tmp_path / "config.json"))], load_from_config=True)
         assert (
             str(warnings[0].message) == "The following keys from the provided configuration file were not consumed: d"
         )
@@ -103,7 +107,7 @@ class TestParseFromFileNoDefaults:
     def test_parse_with_file_fields_remain_required(self, tmp_path: Path, capsys) -> None:
         (tmp_path / "config.json").write_text(dumps({"a": 6, "b": "something"}))
         with raises(SystemExit):
-            parse(self.Config, ["--file", str((tmp_path / "config.json"))], load_from_file=True)
+            parse(self.Config, ["--config-file", str((tmp_path / "config.json"))], load_from_config=True)
         captured = capsys.readouterr()
         assert "the following arguments are required: --a, b" in captured.err
 
@@ -112,13 +116,13 @@ class TestFileCollision:
     @dataclass
     class Config:
         a: int = 5
-        file: Optional[Path] = None
+        config_file: Optional[Path] = None
 
     def test_parse_no_file(self) -> None:
-        config = parse(self.Config, [], load_from_file=False)
+        config = parse(self.Config, [], load_from_config=False)
         assert config.a == 5
-        assert config.file is None
+        assert config.config_file is None
 
     def test_parse_with_file(self, tmp_path: Path) -> None:
         with raises(ArgumentError):
-            parse(self.Config, [], load_from_file=True)
+            parse(self.Config, [], load_from_config=True)

--- a/tests/test_from_file.py
+++ b/tests/test_from_file.py
@@ -33,7 +33,7 @@ class TestParseFromFile:
         z: str = "dummy"
 
     def test_parse_no_file(self) -> None:
-        config = parse(self.Config, [], load_from_config=True)
+        config = parse(self.Config, [], add_config_file_argument=True)
         assert config.a == 5
         assert config.b == "something"
         assert config.c is False
@@ -41,7 +41,7 @@ class TestParseFromFile:
 
     def test_parse_with_file(self, tmp_path: Path) -> None:
         (tmp_path / "config.json").write_text(dumps({"a": 6}))
-        config = parse(self.Config, ["--config-file", str((tmp_path / "config.json"))], load_from_config=True)
+        config = parse(self.Config, ["--config-file", str((tmp_path / "config.json"))], add_config_file_argument=True)
         assert config.a == 6
         assert config.b == "something"
         assert config.c is False
@@ -50,7 +50,7 @@ class TestParseFromFile:
     def test_parse_with_file_override(self, tmp_path: Path) -> None:
         (tmp_path / "config.json").write_text(dumps({"a": 6}))
         config = parse(
-            self.Config, ["--config-file", str((tmp_path / "config.json")), "--a", "7"], load_from_config=True
+            self.Config, ["--config-file", str((tmp_path / "config.json")), "--a", "7"], add_config_file_argument=True
         )
         assert config.a == 7
         assert config.b == "something"
@@ -60,7 +60,7 @@ class TestParseFromFile:
     def test_nested_with_file_and_override(self, tmp_path: Path) -> None:
         (tmp_path / "config.yaml").write_text(dump({"a": 6, "s": {"a": 1, "b": "c", "s": {"q": "z"}}}))
         config = parse(
-            self.Config, ["--config-file", str((tmp_path / "config.yaml")), "--s-b", "d"], load_from_config=True
+            self.Config, ["--config-file", str((tmp_path / "config.yaml")), "--s-b", "d"], add_config_file_argument=True
         )
         assert config.a == 6
         assert config.b == "something"
@@ -72,7 +72,7 @@ class TestParseFromFile:
 
     def test_nested_with_prefixed_keys(self, tmp_path: Path) -> None:
         (tmp_path / "config.yaml").write_text(dump({"a": 6, "s_a": 1, "s": {"b": "c"}}))
-        config = parse(self.Config, ["--config-file", str((tmp_path / "config.yaml"))], load_from_config=True)
+        config = parse(self.Config, ["--config-file", str((tmp_path / "config.yaml"))], add_config_file_argument=True)
         assert config.a == 6
         assert config.s.a == 1
         assert config.s.b == "c"
@@ -80,17 +80,17 @@ class TestParseFromFile:
     def test_nested_with_duplicate_keys(self, tmp_path: Path) -> None:
         (tmp_path / "config.yaml").write_text(dump({"a": 6, "s_a": 1, "s": {"a": 2, "b": "c"}}))
         with raises(KeyError) as e:
-            parse(self.Config, ["--config-file", str((tmp_path / "config.yaml"))], load_from_config=True)
+            parse(self.Config, ["--config-file", str((tmp_path / "config.yaml"))], add_config_file_argument=True)
         assert str(e.value) == "'Collision between keys in config file on key s_a.'"
 
     def test_parse_with_nonexistent_file(self, tmp_path: Path) -> None:
         with raises(FileNotFoundError):
-            parse(self.Config, ["--config-file", str((tmp_path / "config.json"))], load_from_config=True)
+            parse(self.Config, ["--config-file", str((tmp_path / "config.json"))], add_config_file_argument=True)
 
     def test_parse_with_extra_fields(self, tmp_path: Path) -> None:
         (tmp_path / "config.json").write_text(dumps({"a": 6, "d": "this_is_extra"}))
         with warns(UserWarning) as warnings:
-            parse(self.Config, ["--config-file", str((tmp_path / "config.json"))], load_from_config=True)
+            parse(self.Config, ["--config-file", str((tmp_path / "config.json"))], add_config_file_argument=True)
         assert (
             str(warnings[0].message) == "The following keys from the provided configuration file were not consumed: d"
         )
@@ -107,7 +107,7 @@ class TestParseFromFileNoDefaults:
     def test_parse_with_file_fields_remain_required(self, tmp_path: Path, capsys) -> None:
         (tmp_path / "config.json").write_text(dumps({"a": 6, "b": "something"}))
         with raises(SystemExit):
-            parse(self.Config, ["--config-file", str((tmp_path / "config.json"))], load_from_config=True)
+            parse(self.Config, ["--config-file", str((tmp_path / "config.json"))], add_config_file_argument=True)
         captured = capsys.readouterr()
         assert "the following arguments are required: --a, b" in captured.err
 
@@ -119,10 +119,10 @@ class TestFileCollision:
         config_file: Optional[Path] = None
 
     def test_parse_no_file(self) -> None:
-        config = parse(self.Config, [], load_from_config=False)
+        config = parse(self.Config, [], add_config_file_argument=False)
         assert config.a == 5
         assert config.config_file is None
 
     def test_parse_with_file(self, tmp_path: Path) -> None:
         with raises(ArgumentError):
-            parse(self.Config, [], load_from_config=True)
+            parse(self.Config, [], add_config_file_argument=True)

--- a/tests/test_from_file.py
+++ b/tests/test_from_file.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass, field
+from json import dumps
+from pathlib import Path
+from yaml import dump
+
+
+from pydargs import parse
+
+
+@dataclass
+class SubConfig:
+    a: int = 42
+    b: str = field(default="abc", metadata=dict(help="a string"))
+
+
+class TestParseFromFile:
+    @dataclass
+    class Config:
+        a: int = 5
+        b: str = field(default="something", metadata={"ignore_arg": True})
+        c: bool = field(default=False, metadata=dict(ignore_arg=False, as_flags=True))
+        s: SubConfig = field(default_factory=SubConfig)
+        z: str = "dummy"
+
+    def test_parse_no_file(self) -> None:
+        config = parse(self.Config, [], load_from_file=True)
+        assert config.a == 5
+        assert config.b == "something"
+        assert config.c is False
+        assert config.z == "dummy"
+
+    def test_parse_with_file(self, tmp_path: Path) -> None:
+        (tmp_path / "config.json").write_text(dumps({"a": 6}))
+        config = parse(self.Config, ["--file", str((tmp_path / "config.json"))], load_from_file=True)
+        assert config.a == 6
+        assert config.b == "something"
+        assert config.c is False
+        assert config.z == "dummy"
+
+    def test_parse_with_file_override(self, tmp_path: Path) -> None:
+        (tmp_path / "config.json").write_text(dumps({"a": 6}))
+        config = parse(self.Config, ["--file", str((tmp_path / "config.json")), "--a", "7"], load_from_file=True)
+        assert config.a == 7
+        assert config.b == "something"
+        assert config.c is False
+        assert config.z == "dummy"
+
+    def test_nested_with_file_and_override(self, tmp_path: Path) -> None:
+        (tmp_path / "config.yaml").write_text(dump({"a": 6, "s": {"a": 1, "b": "c"}}))
+        config = parse(self.Config, ["--file", str((tmp_path / "config.yaml")), "--s-b", "d"], load_from_file=True)
+        assert config.a == 6
+        assert config.b == "something"
+        assert config.c is False
+        assert config.z == "dummy"
+        assert config.s.a == 1
+        assert config.s.b == "d"
+
+
+# TODO: test without defaults in dataclass
+# TODO: test positionals in dataclass
+# TODO: nested
+# TODO: test extra fields in config
+# TODO: test 'file' field in config, collision
+# TODO: test incorrect path

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Union
+from sys import version_info
 
 from pytest import mark, raises
 
@@ -52,6 +53,7 @@ class TestParseAction:
         captured = capsys.readouterr()
         assert help_string in captured.out.replace("\n", "")
 
+    @mark.skipif(version_info < (3, 10), reason="python3.9 prints s slightly different help")
     @mark.parametrize(
         "help_string",
         ["prog Action1 [-h] --a A [--b B]", "options:  -h"],

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -100,7 +100,9 @@ class TestParseCommand:
         (tmp_path / "config.yaml").write_text(dump({"var": 100, "command": {"b": "b", "c": 0}}))
         with warns(UserWarning) as warnings:
             config = parse(
-                self.Config, ["--file", str((tmp_path / "config.yaml")), "Command1", "--a", "123"], load_from_file=True
+                self.Config,
+                ["--config-file", str((tmp_path / "config.yaml")), "Command1", "--a", "123"],
+                load_from_config=True,
             )
         assert config.var == 100
         assert isinstance(config.command, Command1)

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -102,7 +102,7 @@ class TestParseCommand:
             config = parse(
                 self.Config,
                 ["--config-file", str((tmp_path / "config.yaml")), "Command1", "--a", "123"],
-                load_from_config=True,
+                add_config_file_argument=True,
             )
         assert config.var == 100
         assert isinstance(config.command, Command1)

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Union
 from sys import version_info
+from yaml import dump
 
-from pytest import mark, raises
+from pytest import mark, raises, warns
 
 from pydargs import parse
 
@@ -93,6 +95,21 @@ class TestParseCommand:
         assert config.command.c == 12
         assert config.command.e == "positional"
         assert config.flag is False
+
+    def test_from_file(self, tmp_path: Path):
+        (tmp_path / "config.yaml").write_text(dump({"var": 100, "command": {"b": "b", "c": 0}}))
+        with warns(UserWarning) as warnings:
+            config = parse(
+                self.Config, ["--file", str((tmp_path / "config.yaml")), "Command1", "--a", "123"], load_from_file=True
+            )
+        assert config.var == 100
+        assert isinstance(config.command, Command1)
+        assert config.command.a == 123
+        assert config.command.b == "b"
+        assert (
+            str(warnings[0].message)
+            == "The following keys from the provided configuration file were not consumed: command_c"
+        )
 
 
 class TestDoubleCommand:

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass, field
+from json import dumps
+from pathlib import Path
 from typing import Union
 from sys import version_info
 
-from pytest import mark, raises
+from pytest import mark, raises, warns
 
 from pydargs import parse
 
@@ -94,6 +96,14 @@ class TestParseAction:
         assert config.action.c == 12
         assert config.action.e == "positional"
         assert config.flag is False
+
+    def test_parse_file(self, tmp_path: Path, recwarn) -> None:
+        (tmp_path / "config.json").write_text(dumps({"var": -1, "action_a": 0, "action_c": 0}))
+        with warns(UserWarning):  # Warn for the unused `action_a`
+            config = parse(self.Config, ["--file", str(tmp_path / "config.json"), "Action2"], load_from_file=True)
+        assert isinstance(config.action, Action2)
+        assert config.action.c == 0
+        assert config.var == -1
 
 
 class TestDoubleAction:

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -1,0 +1,263 @@
+from dataclasses import dataclass, field
+from typing import Union
+
+from pytest import mark, raises
+
+from pydargs import parse
+
+
+@dataclass
+class Action1:
+    a: int
+    b: str = "abc"
+
+
+@dataclass
+class Action2:
+    c: int = 42
+    b: str = "abc"
+    e: str = field(default="def", metadata=dict(positional=True))
+
+
+@dataclass
+class Action3:
+    d: float
+    e: list[str] = field(default_factory=lambda: ["def"])
+
+
+@dataclass
+class Action4:
+    sub_action: Union[Action1, Action2]
+    string4: str = "four"
+
+
+class TestParseAction:
+    @dataclass
+    class Config:
+        action: Union[Action1, Action2]
+        var: int = 12
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    @mark.parametrize(
+        "help_string",
+        [
+            "usage: prog [-h] [--var VAR] [--flag | --no-flag]",
+            "{Action1,action1,Action2,action2} ...",
+            "action:  {Action1,action1,Action2,action2}",
+        ],
+    )
+    def test_help(self, capsys, help_string: str):
+        with raises(SystemExit):
+            parse(self.Config, ["--help"], prog="prog")  # type: ignore
+        captured = capsys.readouterr()
+        assert help_string in captured.out.replace("\n", "")
+
+    @mark.parametrize(
+        "help_string",
+        ["prog Action1 [-h] --a A [--b B]", "options:  -h"],
+    )
+    def test_action_help(self, capsys, help_string: str):
+        with raises(SystemExit):
+            parse(self.Config, ["Action1", "--help"], prog="prog")  # type: ignore
+        captured = capsys.readouterr()
+        for line in captured.out.split("\n"):
+            print(line)
+        assert help_string in captured.out.replace("\n", "")
+        assert "prog Action1 [-h] --a A [--b B]" in captured.out.replace("\n", "")
+
+    def test_is_required(self, capsys):
+        with raises(SystemExit):
+            parse(self.Config, [])
+        captured = capsys.readouterr()
+        assert "the following arguments are required: action" in captured.err
+
+    def test_flag(self, capsys):
+        config = parse(self.Config, ["--flag", "Action2"])
+        assert isinstance(config.action, Action2)
+        assert config.action.c == 42
+        assert config.action.b == "abc"
+        assert config.flag is True
+
+        # Verify that the order matters
+        with raises(SystemExit):
+            parse(self.Config, ["Action2", "--flag"])
+        captured = capsys.readouterr()
+        assert "unrecognized arguments: --flag" in captured.err
+
+    def test_action_args(self):
+        config = parse(self.Config, ["Action1", "--a", "12"])
+        assert config.action.a == 12
+        assert config.flag is False
+
+    def test_parse_positional(self):
+        config = parse(self.Config, ["Action2", "positional", "--c", "12"])
+        assert config.action.c == 12
+        assert config.action.e == "positional"
+        assert config.flag is False
+
+
+class TestDoubleAction:
+    @dataclass
+    class Config:
+        action: Union[Action1, Action2]
+        second_action: Union[Action1, Action2, Action3] = field(default_factory=lambda: Action1(a=1))
+        var: int = 12
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    def test_is_not_allowed(self, capsys):
+        with raises(SystemExit):
+            parse(self.Config, [])
+        captured = capsys.readouterr()
+        assert "error: cannot have multiple subparser arguments" in captured.err
+
+
+class TestActionDefault:
+    @dataclass
+    class Config:
+        mode: Union[Action1, Action2, Action3] = field(default_factory=lambda: Action1(0))
+        var: int = 12
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    def test_is_not_required(self, capsys):
+        config = parse(self.Config, [])
+        assert config.mode == Action1(0)
+        assert config.var == 12
+        assert not config.flag
+
+    def test_args(self, capsys):
+        config = parse(self.Config, ["--flag", "Action3", "--d", "0"])
+        assert isinstance(config.mode, Action3)
+        assert config.mode.d == 0
+        assert config.flag is True
+
+        # Verify that the order matters
+        with raises(SystemExit):
+            parse(self.Config, ["Action2", "--flag"])
+        captured = capsys.readouterr()
+        assert "unrecognized arguments: --flag" in captured.err
+
+
+class TestNestedAction:
+    @dataclass
+    class Config:
+        mode: Union[Action1, Action2, Action3, Action4] = field(default_factory=lambda: Action1(0))
+        var: int = 12
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    def test_is_not_required(self, capsys):
+        config = parse(self.Config, [])
+        assert config.mode == Action1(0)
+        assert config.var == 12
+        assert not config.flag
+
+    def test_args(self, capsys):
+        config = parse(self.Config, ["Action4", "Action1", "--a", "-3"])
+        assert isinstance(config.mode, Action4)
+        assert isinstance(config.mode.sub_action, Action1)
+        assert config.mode.sub_action.a == -3
+
+
+class TestCollision:
+    @dataclass
+    class Config:
+        action: Union[Action1, Action2]
+        a: int = 2
+        d: int = 3
+
+    def test_help(self, capsys):
+        with raises(SystemExit):
+            parse(self.Config, ["Action1", "--help"], prog="prog")  # type: ignore
+        captured = capsys.readouterr()
+        assert "prog Action1 [-h] --a A [--b B]" in captured.out.replace("\n", "")
+
+    def test_collision(self, capsys):
+        config = parse(self.Config, ["--a", "4", "--d", "4", "Action1", "--a", "3"])
+        assert config.action.a == 3
+        assert config.d == 4
+        assert config.a == 4
+
+    def test_other_option(self):
+        config = parse(self.Config, ["--a", "4", "--d", "4", "Action2"])
+        assert config.action.c == 42
+        assert config.d == 4
+        assert config.a == 4
+
+
+class TestPositionalAndSubparser:
+    @dataclass
+    class Config:
+        positional_1: str = field(metadata=dict(positional=True))
+        action: Union[Action1, Action2]
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+        positional_2: str = field(default="five", metadata=dict(positional=True))
+
+    def test_warn_positional_after_subparser(self, recwarn):
+        _ = parse(
+            self.Config,
+            ["positional", "Action1", "--a", "12", "--b", "20"],
+        )
+        assert len(recwarn) == 1
+
+    def test_parse_positional(self, recwarn):
+        config = parse(
+            self.Config,
+            ["positional", "Action1", "--a", "12", "--b", "20"],
+        )
+        assert config.positional_1 == "positional"
+
+
+class TestParseActionInNested:
+    @dataclass
+    class Config:
+        sub: Action4
+        var: int = 12
+        flag: bool = field(default=False, metadata=dict(as_flags=True))
+
+    @mark.parametrize(
+        "help_string",
+        [
+            "usage: prog [-h] [--sub-string4 SUB_STRING4] [--var VAR] [--flag | --no-flag]",
+            "{Action1,action1,Action2,action2} ...",
+            "action:  {Action1,action1,Action2,action2}",
+        ],
+    )
+    def test_help(self, capsys, help_string: str):
+        with raises(SystemExit):
+            parse(self.Config, ["--help"], prog="prog")  # type: ignore
+        captured = capsys.readouterr()
+        assert help_string in captured.out.replace("\n", "")
+
+    def test_action_help(self, capsys):
+        with raises(SystemExit):
+            parse(self.Config, ["Action1", "--help"], prog="prog")  # type: ignore
+        captured = capsys.readouterr()
+        assert "prog Action1 [-h] --sub-a SUB_A [--sub-b SUB_B]" in captured.out.replace("\n", "")
+
+    def test_is_required(self, capsys):
+        with raises(SystemExit):
+            parse(self.Config, [])
+        captured = capsys.readouterr()
+        assert "the following arguments are required: sub_sub_action" in captured.err
+
+    def test_flag(self, capsys):
+        config = parse(self.Config, ["--flag", "Action2"])
+        assert isinstance(config.sub, Action4)
+        assert isinstance(config.sub.sub_action, Action2)
+        assert config.flag is True
+
+        # Verify that the order matters
+        with raises(SystemExit):
+            parse(self.Config, ["Action2", "--flag"])
+        captured = capsys.readouterr()
+        assert "unrecognized arguments: --flag" in captured.err
+
+    def test_action_args(self):
+        config = parse(self.Config, ["Action1", "--sub-a", "12"])
+        assert config.sub.sub_action.a == 12
+        assert config.flag is False
+
+    def test_parse_positional(self):
+        config = parse(self.Config, ["Action2", "positional", "--sub-c", "12"])
+        assert config.sub.sub_action.c == 12
+        assert config.sub.sub_action.e == "positional"
+        assert config.flag is False

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -62,8 +62,6 @@ class TestParseAction:
         with raises(SystemExit):
             parse(self.Config, ["Action1", "--help"], prog="prog")  # type: ignore
         captured = capsys.readouterr()
-        for line in captured.out.split("\n"):
-            print(line)
         assert help_string in captured.out.replace("\n", "")
         assert "prog Action1 [-h] --a A [--b B]" in captured.out.replace("\n", "")
 


### PR DESCRIPTION
Add an option (`load_from_config: bool`) which allows reading a JSON/YAML-formatted file to override any defaults.